### PR TITLE
wrong manual fix of merge conflict fixed

### DIFF
--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -915,7 +915,7 @@ void OnGetConfig()
 {
   lastCommand = millis();
   cmdMessenger.sendCmdStart(kInfo);
-  cmdMessenger.sendArg(MFeeprom.read_char(MEM_OFFSET_CONFIG));
+  cmdMessenger.sendCmdArg(MFeeprom.read_char(MEM_OFFSET_CONFIG));
   for (uint16_t i=1; i<configLength; i++) {
     cmdMessenger.sendArg(MFeeprom.read_char(MEM_OFFSET_CONFIG+i));
   }


### PR DESCRIPTION
by resolving a merge conflict accidentily the transfer of the config was broken.
Within OnGetConfig() it must be sendCmdArg() and not sendArg(). Without this change the limiter is missing and the config is not recognized from the connector