### PR TITLE
ProMicro filename is wrong

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -40,7 +40,7 @@ monitor_speed = 115200
 extra_scripts = 
 	pre:get_version.py
 
-[env:promicro]
+[env:micro]
 platform = atmelavr
 board = sparkfun_promicro16
 framework = arduino


### PR DESCRIPTION
Fixes #82

## Description of changes

Change the name of the platform in platformio.ini so the firmware has the correct name