### PR TITLE
Add CodeTour to recommended VSCode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "platformio.platformio-ide"
+        "platformio.platformio-ide",
+        "vsls-contrib.codetour"
     ]
 }


### PR DESCRIPTION
Fixes #89

Adds the CodeTour extension to `.vscode/extensions.json`.