### PR TITLE
Fix: corrected byte count in shift (NEW PR)

### DIFF
--- a/src/MF_Modules/MFShifter.cpp
+++ b/src/MF_Modules/MFShifter.cpp
@@ -90,8 +90,8 @@ void MFShifter::test()
 void MFShifter::updateShiftRegister()
 {
    digitalWrite(_latchPin, LOW);
-   for (int i = _moduleCount; i >=0 ; i--) {
-      shiftOut(_dataPin, _clockPin, MSBFIRST, (_output >> i*8)); //LSBFIRST, MSBFIRST,
+   for (uint8_t i = _moduleCount; i>0 ; i--) {
+      shiftOut(_dataPin, _clockPin, MSBFIRST, (_output >> ((i-1)*8))); //LSBFIRST, MSBFIRST,
    }    
    digitalWrite(_latchPin, HIGH);
 }


### PR DESCRIPTION
(Replaces PR #79)
Fixes  #80:
The count of bytes shifted out was incorrect. It did not affect operation because the excess byte was on the tail end and was discarded, however it unnecessarily increased timing and might cause problems in the future.