### PR TITLE
Support any combination of row/column counts for LCD displays

### DIFF
--- a/src/MF_Modules/MFLCDDisplay.cpp
+++ b/src/MF_Modules/MFLCDDisplay.cpp
@@ -18,7 +18,10 @@ void MFLCDDisplay::display(const char *string)
     _lcdDisplay->setCursor(0, line);
     for (uint8_t col = 0; col < _cols; col++)
     {
-      _lcdDisplay->write(string[(_cols * line) + col]);
+      uint8_t char2print = string[(_cols * line) + col];
+      if (!char2print)                                     // just to be sure not to print after NULL termination
+        return;
+      _lcdDisplay->write(char2print);
     }
   }
 }

--- a/src/MF_Modules/MFLCDDisplay.cpp
+++ b/src/MF_Modules/MFLCDDisplay.cpp
@@ -13,12 +13,13 @@ void MFLCDDisplay::display(const char *string)
 {
   if (!_initialized)
     return;
-  char readBuffer[21] = "";
-  for (byte l = 0; l != _lines; l++)
+  for (uint8_t line = 0; line != _lines; line++)
   {
-    _lcdDisplay->setCursor(0, l);
-    memcpy(readBuffer, string + _cols * l, _cols);
-    _lcdDisplay->print(readBuffer);
+    _lcdDisplay->setCursor(0, line);
+    for (uint8_t col = 0; col < _cols; col++)
+    {
+      _lcdDisplay->write(string[(_cols * line) + col]);
+    }
   }
 }
 

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -915,7 +915,7 @@ void OnGetConfig()
 {
   lastCommand = millis();
   cmdMessenger.sendCmdStart(kInfo);
-  cmdMessenger.sendArg(MFeeprom.read_char(MEM_OFFSET_CONFIG));
+  cmdMessenger.sendCmdArg(MFeeprom.read_char(MEM_OFFSET_CONFIG));
   for (uint16_t i=1; i<configLength; i++) {
     cmdMessenger.sendArg(MFeeprom.read_char(MEM_OFFSET_CONFIG+i));
   }


### PR DESCRIPTION
Fixes #85

Instead of copying the single line to a buffer, print directly from the char buffer containing the complete message via ->write().

Tested with a 20x4 LCD, but will work with any combination of columns and rows.