### PR TITLE
Changes for modified LiquidCrystal_I2C lib

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,8 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C
+;	https://github.com/MobiFlight/LiquidCrystal_I2C
+	https://github.com/elral/LiquidCrystal_I2C#changed_init
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,8 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C
+;	https://github.com/MobiFlight/LiquidCrystal_I2C
+	https://github.com/elral/LiquidCrystal_I2C#changed_init
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 
@@ -60,7 +61,8 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C
+;	https://github.com/MobiFlight/LiquidCrystal_I2C
+	https://github.com/elral/LiquidCrystal_I2C#changed_init
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 
@@ -85,7 +87,8 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C
+;	https://github.com/MobiFlight/LiquidCrystal_I2C
+	https://github.com/elral/LiquidCrystal_I2C#changed_init
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -61,7 +61,8 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C
+;	https://github.com/MobiFlight/LiquidCrystal_I2C
+	https://github.com/elral/LiquidCrystal_I2C#changed_init
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 
@@ -86,7 +87,8 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C
+;	https://github.com/MobiFlight/LiquidCrystal_I2C
+	https://github.com/elral/LiquidCrystal_I2C#changed_init
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,8 +35,7 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-;	https://github.com/MobiFlight/LiquidCrystal_I2C
-	https://github.com/elral/LiquidCrystal_I2C#changed_init
+	https://github.com/MobiFlight/LiquidCrystal_I2C
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 
@@ -61,8 +60,7 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-;	https://github.com/MobiFlight/LiquidCrystal_I2C
-	https://github.com/elral/LiquidCrystal_I2C#changed_init
+	https://github.com/MobiFlight/LiquidCrystal_I2C
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 
@@ -87,8 +85,7 @@ lib_deps =
 	arduino-libraries/Servo @ ^1.1.8
 	https://github.com/MobiFlight/LedControl
 	waspinator/AccelStepper @ ^1.61
-;	https://github.com/MobiFlight/LiquidCrystal_I2C
-	https://github.com/elral/LiquidCrystal_I2C#changed_init
+	https://github.com/MobiFlight/LiquidCrystal_I2C
 	https://github.com/MobiFlight/Arduino-CmdMessenger
 monitor_speed = 115200
 extra_scripts = 

--- a/src/MF_Modules/MFLCDDisplay.cpp
+++ b/src/MF_Modules/MFLCDDisplay.cpp
@@ -13,17 +13,15 @@ void MFLCDDisplay::display(const char *string)
 {
   if (!_initialized)
     return;
-  for (uint8_t line = 0; line != _lines; line++)
+ for (uint8_t line = 0; line != _lines; line++)
   {
     _lcdDisplay->setCursor(0, line);
-    for (uint8_t col = 0; col < _cols; col++)
-    {
-      uint8_t char2print = string[(_cols * line) + col];
-      if (!char2print)                                     // just to be sure not to print after NULL termination
-        return;
-      _lcdDisplay->write(char2print);
-    }
+    _lcdDisplay->writeString(&string[line*_cols], _cols);
+
   }
+
+//_lcdDisplay.writeString(string);
+
 }
 
 void MFLCDDisplay::attach(byte address, byte cols, byte lines)

--- a/src/MF_Modules/MFLCDDisplay.cpp
+++ b/src/MF_Modules/MFLCDDisplay.cpp
@@ -35,6 +35,7 @@ void MFLCDDisplay::attach(byte address, byte cols, byte lines)
   _initialized = true;
   _lcdDisplay->init((uint8_t)address, (uint8_t)cols, (uint8_t)lines);
   _lcdDisplay->backlight();
+  Wire.setClock(400000);
   test();
 }
 

--- a/src/MF_Modules/MFLCDDisplay.cpp
+++ b/src/MF_Modules/MFLCDDisplay.cpp
@@ -13,14 +13,14 @@ void MFLCDDisplay::display(const char *string)
 {
   if (!_initialized)
     return;
+/*    Fallback solution if line wrapping does not work on all LCD's (but should)
  for (uint8_t line = 0; line != _lines; line++)
   {
     _lcdDisplay->setCursor(0, line);
     _lcdDisplay->writeString(&string[line*_cols], _cols);
-
   }
-
-//_lcdDisplay.writeString(string);
+*/
+_lcdDisplay->writeString(string);
 
 }
 

--- a/src/MF_Modules/MFLCDDisplay.cpp
+++ b/src/MF_Modules/MFLCDDisplay.cpp
@@ -31,9 +31,9 @@ void MFLCDDisplay::attach(byte address, byte cols, byte lines)
   _address = address;
   _cols = cols;
   _lines = lines;
-  _lcdDisplay = new LiquidCrystal_I2C((uint8_t)address, (uint8_t)cols, (uint8_t)lines);
+  _lcdDisplay = new LiquidCrystal_I2C();
   _initialized = true;
-  _lcdDisplay->init();
+  _lcdDisplay->init((uint8_t)address, (uint8_t)cols, (uint8_t)lines);
   _lcdDisplay->backlight();
   test();
 }


### PR DESCRIPTION
## Description of changes
With pull request https://github.com/MobiFlight/LiquidCrystal_I2C/pull/1 the parameters are moved from the constructor to the init() function. Therefore this has to be changed also in the firmware.
