### PR TITLE
Enabled deferring of servo processing to smooth movement

### DIFF
--- a/include/MFServo.h
+++ b/include/MFServo.h
@@ -38,8 +38,7 @@ private:
     bool    _initialized;
     Servo   _servo;
     long    _targetPos;
-    long    _currentPos;
-    unsigned long _lastUpdate;
+    long    _currentPos;    
     int     speed;
 };
 #endif 

--- a/include/mobiflight.h
+++ b/include/mobiflight.h
@@ -5,6 +5,7 @@
 #include <MFAnalog.h>
 
 #define MF_BUTTON_DEBOUNCE_MS   10      // time between updating the buttons
+#define MF_SERVO_DELAY_MS       5       // Time between servo updates
 
 enum
 {

--- a/src/MF_Modules/MFServo.cpp
+++ b/src/MF_Modules/MFServo.cpp
@@ -25,7 +25,8 @@ void MFServo::update() {
 		return; 
 	}
 	
-    //if ((millis()-_lastUpdate) < 5) return;
+	// Defer further processing until at least 5ms has elapsed
+    if ((millis()-_lastUpdate) < 5) return;
     
     if (_currentPos > _targetPos) _currentPos--;
     else _currentPos++;

--- a/src/MF_Modules/MFServo.cpp
+++ b/src/MF_Modules/MFServo.cpp
@@ -24,14 +24,10 @@ void MFServo::update() {
 		// detach(); 
 		return; 
 	}
-	
-	// Defer further processing until at least 5ms has elapsed
-    if ((millis()-_lastUpdate) < 5) return;
     
     if (_currentPos > _targetPos) _currentPos--;
     else _currentPos++;
-    
-    _lastUpdate = millis();
+        
     _servo.write(_currentPos);
 }
 
@@ -49,8 +45,7 @@ void MFServo::attach(uint8_t pin, bool enable)
 	_currentPos = 0;
 	setExternalRange(0,180);
 	setInternalRange(0,180);
-	_pin = pin;		
-	_lastUpdate = millis();
+	_pin = pin;	
 }
 
 MFServo::MFServo() : _servo() {}

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -63,6 +63,7 @@ uint32_t lastAnalogAverage = 0;
 uint32_t lastAnalogRead = 0;
 uint32_t lastButtonUpdate= 0;
 uint32_t lastEncoderUpdate = 0;
+uint32_t lastServoUpdate = 0;
 
 const char type[sizeof(MOBIFLIGHT_TYPE)] = MOBIFLIGHT_TYPE;
 char serial[MEM_LEN_SERIAL] = MOBIFLIGHT_SERIAL;
@@ -210,6 +211,7 @@ void setup()
   lastAnalogRead = millis() + 4;
   lastButtonUpdate= millis();
   lastEncoderUpdate = millis() +2;
+  lastServoUpdate = millis();
 }
 
 void generateSerial(bool force)
@@ -1019,6 +1021,9 @@ void OnSetServo()
 
 void updateServos()
 {
+  if (millis()-lastServoUpdate <= MF_SERVO_DELAY_MS) return;
+  lastServoUpdate = millis();
+
   for (int i = 0; i != servosRegistered; i++)
   {
     servos[i].update();


### PR DESCRIPTION
## Description of changes

Fixes #107

Servo update code now defers processing for at least 5ms for each tick. This ensures the servo's internally tracked position isn't moved towards the goal at a non-regulated rate. As a result the servo movement appears smoother, especially in the case of config timer internal being set to higher values.