### PR TITLE
Read time for buttons and analog in is wrong Fixes #113

### DIFF
--- a/include/mobiflight.h
+++ b/include/mobiflight.h
@@ -5,6 +5,8 @@
 #include <MFAnalog.h>
 
 #define MF_BUTTON_DEBOUNCE_MS   10      // time between updating the buttons
+#define MF_ANALOGAVERAGE_DELAY_MS 10    // time between updating the analog average calculation
+#define MF_ANALOGREAD_DELAY_MS  50      // time between sending analog values
 
 enum
 {

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -1038,7 +1038,7 @@ void OnSetLcdDisplayI2C()
 
 void readButtons()
 {
-  if (millis()-lastButtonUpdate <= MF_BUTTON_DEBOUNCE_MS) return;
+  if (millis()-lastButtonUpdate < MF_BUTTON_DEBOUNCE_MS) return;
   lastButtonUpdate= millis();
   for (int i = 0; i != buttonsRegistered; i++)
   {
@@ -1059,14 +1059,14 @@ void readEncoder()
 #if MF_ANALOG_SUPPORT == 1
 void readAnalog()
 {
-  if (millis()-lastAnalogAverage > 10) {
+  if (millis()-lastAnalogAverage > MF_ANALOGAVERAGE_DELAY_MS - 1) {
     for (int i = 0; i != analogRegistered; i++)
     {
       analog[i].readBuffer();
     }
     lastAnalogAverage = millis();
   }
-  if (millis()-lastAnalogRead < 50) return;
+  if (millis()-lastAnalogRead < MF_ANALOGREAD_DELAY_MS) return;
   lastAnalogRead = millis();
   for (int i = 0; i != analogRegistered; i++)
   {


### PR DESCRIPTION
Read in time for buttons reduced from 11ms to 10ms as originally intended
Read in time for analog average reduced from 11ms to 10ms as originally intended

Fixes #113

