### PR TITLE
After start first step of enc is always fast step

### DIFF
--- a/src/MF_Modules/MFEncoder.cpp
+++ b/src/MF_Modules/MFEncoder.cpp
@@ -70,7 +70,8 @@ void MFEncoder::attach(uint8_t pin1, uint8_t pin2, uint8_t TypeEncoder, const ch
   _oldState = 0;
   _position = 0;
   _positionExt = 0;
-
+  _positionTimePrev = 0;              // for first startup avoid calculation of a high speed, _positionTimePrev
+  _positionTime = 500;                // and _positionTime must be initialized to avoid that they have the same value
   _initialized = true;
 }
 


### PR DESCRIPTION
Fixes #120
First step of an encoder after startup is always a fast step. This is due to missing initialization of _positionTimePrev and _positionTime. Therefore they have the same value and a high speed is calculated.