### PR TITLE
Config Buffer gets filled with unnecessary bytes

### DIFF
--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -673,7 +673,7 @@ void OnSetConfig()
 
   if (configLength + cfgLen + 1 < MEM_LEN_CONFIG)
   {
-    MFeeprom.write_block(MEM_OFFSET_CONFIG + configLength, cfg, cfgLen+1);    // save the received config string including the terminatung NULL (+1) to EEPROM
+    memcpy(&configBuffer[configLength], cfg, cfgLen+1);       // save the received config string including the terminatung NULL (+1)
     configLength += cfgLen;
     cmdMessenger.sendCmd(kStatus, configLength);
   }

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -670,11 +670,10 @@ void OnSetConfig()
   lastCommand = millis();
   char *cfg = cmdMessenger.readStringArg();
   uint8_t cfgLen = strlen(cfg);
-  uint16_t bufferSize = MEM_LEN_CONFIG - (configLength + cfgLen);
 
-  if (bufferSize > 1)
+  if (configLength + cfgLen + 1 < MEM_LEN_CONFIG)
   {
-    memcpy(&configBuffer[configLength], cfg, bufferSize);
+    MFeeprom.write_block(MEM_OFFSET_CONFIG + configLength, cfg, cfgLen+1);    // save the received config string including the terminatung NULL (+1) to EEPROM
     configLength += cfgLen;
     cmdMessenger.sendCmd(kStatus, configLength);
   }


### PR DESCRIPTION
Fixes #123

configBuffer was on every part of the upload written up to the end of the buffersize. Every byte after the config part came from "somewhere".

With this change only the received part of the config  gets copied.