### PR TITLE
Clean up version number before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ To publish a new release:
 
 1. Go to the [GitHub Releases page](https://github.com/MobiFlight/MobiFlight-FirmwareSource/releases) and
 click the `Draft a new release` button.
-2. Click `Choose a tag` and create a new version tag, e.g. `v1.14.0`. Note that this *must* include the `v`
-at the front for various release scripts to work correctly. 
+2. Click `Choose a tag` and create a new version tag, e.g. `1.14.0`
 3. Enter a title and release notes.
 4. Optionally check `This is a pre-release` if the release should be for testing purposes and not be marked
 as the latest published release.

--- a/get_version.py
+++ b/get_version.py
@@ -10,6 +10,11 @@ if firmware_version == "":
   # compatibility with MobiFlight desktop app version checks.
   firmware_version = "0.0.1"
 
+# Strip any leading "v" that might be on the version and
+# any leading or trailing periods.
+firmware_version = firmware_version.lstrip("v")
+firmware_version = firmware_version.strip(".")
+
 print(f'Using version {firmware_version} for the build')
 
 # Append the version to the build defines so it gets baked into the firmware


### PR DESCRIPTION
Fixes #125

* Strip any leading "v" off the version
* Strip any leading or trailing dots off the version