### PR TITLE
Move common platform.ini pieces to a shared environment block

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,77 +16,74 @@
 ; by clicking on the target name in the bottom status bar.
 [platformio]
 
+; Common build settings across all devices
+[env]
+lib_deps = 
+	arduino-libraries/Servo @ 1.1.8
+	https://github.com/MobiFlight/LedControl#1.1.0
+	waspinator/AccelStepper @ 1.61
+	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4
+	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
+build_flags =
+	-DMF_REDUCE_FUNCT_LEDCONTROL
+	-DMAXCALLBACKS=30
+	-DSERIAL_RX_BUFFER_SIZE=96
+	-DMESSENGERBUFFERSIZE=96
+	-DMAXSTREAMBUFFERSIZE=96
+	-DDEFAULT_TIMEOUT=5000
+src_filter =
+	+<*>
+extra_scripts =
+	pre:get_version.py
+
+; Build settings for the Arduino Mega
 [env:mega]
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
 build_flags = 
-	-DMF_REDUCE_FUNCT_LEDCONTROL
-	-DMAXCALLBACKS=30
-	-DSERIAL_RX_BUFFER_SIZE=96
-	-DMESSENGERBUFFERSIZE=96
-	-DMAXSTREAMBUFFERSIZE=96
-	-DDEFAULT_TIMEOUT=5000
+	${env.build_flags}
 	-I./_Boards/Atmel/Board_Mega
 src_filter = 
-	+<*>
+	${env.src_filter}
 	+<../_Boards/Atmel>
 lib_deps = 
-	arduino-libraries/Servo @ 1.1.8
-	https://github.com/MobiFlight/LedControl#1.1.0
-	waspinator/AccelStepper @ 1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4
-	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
+	${env.lib_deps}	
 monitor_speed = 115200
 extra_scripts = 
-	pre:get_version.py
+	${env.extra_scripts}
 
+; Build settings for the Arduino Pro Micro
 [env:micro]
 platform = atmelavr
 board = sparkfun_promicro16
 framework = arduino
 build_flags = 
-	-DMF_REDUCE_FUNCT_LEDCONTROL
-	-DMAXCALLBACKS=30
-	-DSERIAL_RX_BUFFER_SIZE=96
-	-DMESSENGERBUFFERSIZE=96
-	-DMAXSTREAMBUFFERSIZE=96
-	-DDEFAULT_TIMEOUT=5000
+	${env.build_flags}
 	-I./_Boards/Atmel/Board_ProMicro
 src_filter = 
-	+<*>
+	${env.src_filter}
 	+<../_Boards/Atmel>
 lib_deps = 
-	arduino-libraries/Servo @ 1.1.8
-	https://github.com/MobiFlight/LedControl#1.1.0
-	waspinator/AccelStepper @ 1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4
-	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
+	${env.lib_deps}	
 monitor_speed = 115200
 extra_scripts = 
-	pre:get_version.py
+	${env.extra_scripts}
 
+
+; Build settings for the Arduino Uno
 [env:uno]
 platform = atmelavr
 board = uno
 framework = arduino
 build_flags = 
-	-DMF_REDUCE_FUNCT_LEDCONTROL
-	-DMAXCALLBACKS=30
-	-DSERIAL_RX_BUFFER_SIZE=96
-	-DMESSENGERBUFFERSIZE=96
-	-DMAXSTREAMBUFFERSIZE=96
-	-DDEFAULT_TIMEOUT=5000
+	${env.build_flags}
 	-I./_Boards/Atmel/Board_Uno
 src_filter = 
-	+<*>
+	${env.src_filter}
 	+<../_Boards/Atmel>
 lib_deps = 
-	arduino-libraries/Servo @ 1.1.8
-	https://github.com/MobiFlight/LedControl#1.1.0
-	waspinator/AccelStepper @ 1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4
-	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
+	${env.lib_deps}	
 monitor_speed = 115200
 extra_scripts = 
-	pre:get_version.py
+	${env.extra_scripts}


### PR DESCRIPTION
Fixes #144

Created common `env` sections for the parts of the build definition that are common across all boards.