### PR TITLE
Issue #151 - Brightness=0 completely switches display off

### DIFF
--- a/include/MFSegments.h
+++ b/include/MFSegments.h
@@ -32,8 +32,7 @@ public:
     void setBrightness(byte module, byte value);
 
 private:
-    LedControl _ledControl;
-    //bool _initialized;
-    byte _moduleCount;
+    LedControl  _ledControl;
+    byte        _moduleCount;
 };
 #endif

--- a/include/MFSegments.h
+++ b/include/MFSegments.h
@@ -33,7 +33,7 @@ public:
 
 private:
     LedControl _ledControl;
-    bool _initialized;
+    //bool _initialized;
     byte _moduleCount;
 };
 #endif

--- a/src/MF_Modules/MFSegments.cpp
+++ b/src/MF_Modules/MFSegments.cpp
@@ -4,8 +4,6 @@
 
 #include "MFSegments.h"
 
-#define _initialized  (_moduleCount != 0)
-
 MFSegments::MFSegments()
 {
   _moduleCount = 0;
@@ -13,7 +11,7 @@ MFSegments::MFSegments()
 
 void MFSegments::display(byte module, char *string, byte points, byte mask, bool convertPoints)
 {
-  if (!_initialized)
+  if (_moduleCount == 0)
     return;
   byte digit = 8;
   byte pos = 0;
@@ -29,7 +27,7 @@ void MFSegments::display(byte module, char *string, byte points, byte mask, bool
 
 void MFSegments::setBrightness(byte module, byte value)
 {
-  if (!_initialized)
+  if (_moduleCount == 0)
     return;
   if (module < _moduleCount)
   {
@@ -70,7 +68,7 @@ void MFSegments::powerSavingMode(bool state)
 
 void MFSegments::test()
 {
-  if (!_initialized)
+  if (_moduleCount == 0)
     return;
   byte _delay = 10;
   byte module = 0;

--- a/src/MF_Modules/MFSegments.cpp
+++ b/src/MF_Modules/MFSegments.cpp
@@ -4,16 +4,17 @@
 
 #include "MFSegments.h"
 
+#define _initialized  (_moduleCount != 0)
+
 MFSegments::MFSegments()
 {
-  _initialized = false;
+  _moduleCount = 0;
 }
 
 void MFSegments::display(byte module, char *string, byte points, byte mask, bool convertPoints)
 {
   if (!_initialized)
     return;
-
   byte digit = 8;
   byte pos = 0;
   for (int i = 0; i != 8; i++)
@@ -32,14 +33,19 @@ void MFSegments::setBrightness(byte module, byte value)
     return;
   if (module < _moduleCount)
   {
-    _ledControl.setIntensity(module, value);
+    if(value) 
+    {
+      _ledControl.setIntensity(module, value-1);
+      _ledControl.shutdown(module, false);
+    } else {
+      _ledControl.shutdown(module, true);
+    }
   }
 }
 
 void MFSegments::attach(int dataPin, int csPin, int clkPin, byte moduleCount, byte brightness)
 {
   _ledControl.begin(dataPin, clkPin, csPin, moduleCount);
-  _initialized = true;
   _moduleCount = moduleCount;
   for (int i = 0; i != _moduleCount; ++i)
   {
@@ -51,7 +57,7 @@ void MFSegments::attach(int dataPin, int csPin, int clkPin, byte moduleCount, by
 
 void MFSegments::detach()
 {
-  _initialized = false;
+  _moduleCount = 0;
 }
 
 void MFSegments::powerSavingMode(bool state)


### PR DESCRIPTION
## Description of changes
Implements part of #642: now setting Brightness = 0 completely switches the display off rather than setting minimum brightness.
Actual value sent to the IC is lower by 1 (actual range: 0-14), since value 15 is effectively indistinguishable from 14, but value 0 is a very faint brightness that might be desired in some cases.
Memory occupation has been very slightly reduced by using the value of "_moduleCount" to replace the "_initialized" flag
