### PR TITLE
Fix broken output shifters

### DIFF
--- a/src/MF_Modules/MFOutputShifter.cpp
+++ b/src/MF_Modules/MFOutputShifter.cpp
@@ -16,7 +16,6 @@ void MFOutputShifter::setPin(uint8_t pin, uint8_t value, uint8_t refresh)
 
   uint8_t idx = (pin & 0xF8) >> 3;
   uint8_t msk = (0x01 << (pin & 0x07));
-
   if (value > 0)
   {
     _outputBuffer[idx] |= msk;

--- a/src/MF_Modules/MFOutputShifter.cpp
+++ b/src/MF_Modules/MFOutputShifter.cpp
@@ -11,25 +11,32 @@ MFOutputShifter::MFOutputShifter()
 
 void MFOutputShifter::setPin(uint8_t pin, uint8_t value, uint8_t refresh)
 {
-  if (!_initialized) return;
+  if (!_initialized)
+    return;
 
-  uint8_t idx = (pin & 0xF8)>>3;
+  uint8_t idx = (pin & 0xF8) >> 3;
   uint8_t msk = (0x01 << (pin & 0x07));
-  //if(idx < _moduleCount) return;
-  if (value > 0) {
-    _outputBuffer[idx] |= msk;  
-  } else {
-    _outputBuffer[idx] &= ~msk;  
-  }    
-  if(refresh) updateShiftRegister();
+
+  if (value > 0)
+  {
+    _outputBuffer[idx] |= msk;
+  }
+  else
+  {
+    _outputBuffer[idx] &= ~msk;
+  }
+  if (refresh)
+    updateShiftRegister();
 }
 
-void MFOutputShifter::setPins(char* pins, uint8_t value)
+void MFOutputShifter::setPins(char *pins, uint8_t value)
 {
-  if (!_initialized) return;
+  if (!_initialized)
+    return;
 
-  char* pinTokens = strtok(pins, "|");
-  while (pinTokens != 0) {
+  char *pinTokens = strtok(pins, "|");
+  while (pinTokens != 0)
+  {
     uint8_t num = (uint8_t)atoi(pinTokens);
     setPin(num, value, 0);
     pinTokens = strtok(0, "|");
@@ -46,7 +53,7 @@ void MFOutputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin
   _moduleCount = moduleCount;
 
   pinMode(_latchPin, OUTPUT);
-  pinMode(_clockPin, OUTPUT);  
+  pinMode(_clockPin, OUTPUT);
   pinMode(_dataPin, OUTPUT);
 
   clear();
@@ -54,41 +61,44 @@ void MFOutputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin
 
 void MFOutputShifter::detach()
 {
-  if (!_initialized) return;
+  if (!_initialized)
+    return;
   _initialized = false;
 }
 
-void MFOutputShifter::clear() 
+void MFOutputShifter::clear()
 {
   // Set everything to 0
-  for (uint8_t i = 0; i < _moduleCount; i++) {   
+  for (uint8_t i = 0; i < _moduleCount; i++)
+  {
     _outputBuffer[i] = 0;
   }
-  updateShiftRegister();  
+  updateShiftRegister();
 }
 
-
-void MFOutputShifter::test() 
+void MFOutputShifter::test()
 {
-  for (uint8_t b = 0; b < _moduleCount * 8; b++) {   
-    uint8_t idx = (b & 0xF8)>>3;
+  for (uint8_t b = 0; b < _moduleCount * 8; b++)
+  {
+    uint8_t idx = (b & 0xF8) >> 3;
     uint8_t msk = (0x01 << (b & 0x07));
     _outputBuffer[idx] = msk;
-    if(msk == 0x01 && idx != 0) _outputBuffer[idx-1] = 0x00;
+    if (msk == 0x01 && idx != 0)
+      _outputBuffer[idx - 1] = 0x00;
     updateShiftRegister();
     delay(50);
 
-    _outputBuffer[_moduleCount-1] = 0;
+    _outputBuffer[_moduleCount - 1] = 0;
     updateShiftRegister();
   }
 }
 
-
 void MFOutputShifter::updateShiftRegister()
 {
-   digitalWrite(_latchPin, LOW);
-   for (uint8_t i = _moduleCount; i>0 ; i--) {
-      shiftOut(_dataPin, _clockPin, MSBFIRST, _outputBuffer[i]); //LSBFIRST, MSBFIRST,
-   }    
-   digitalWrite(_latchPin, HIGH);
+  digitalWrite(_latchPin, LOW);
+  for (uint8_t i = _moduleCount; i > 0; i--)
+  {
+    shiftOut(_dataPin, _clockPin, MSBFIRST, _outputBuffer[i - 1]); // LSBFIRST, MSBFIRST,
+  }
+  digitalWrite(_latchPin, HIGH);
 }


### PR DESCRIPTION
Fixes #155

## Description of changes

Adds a `- 1` to the index into `_outputBuffer` so the correct values get sent to the shift register chips.