### PR TITLE
avoid crash if string is longer then columns, Fixes #158

### DIFF
--- a/src/MF_Modules/MFLCDDisplay.cpp
+++ b/src/MF_Modules/MFLCDDisplay.cpp
@@ -81,20 +81,19 @@ void MFLCDDisplay::test()
 
 void MFLCDDisplay::_printCentered(const char *str, uint8_t line)
 {
-  _lcdDisplay->setCursor(0, line);
+  uint8_t startCol = 0;
+  uint8_t printChar = _cols;
+  
   if (_cols > strlen(str))
   {
-    for (byte c = 0; c != ((_cols - strlen(str)) / 2); c++)
-    {
-      _lcdDisplay->print(F(" "));
-    }
-    _lcdDisplay->print(str);
-    for (byte c = 0; c != ((_cols - strlen(str)) / 2); c++)
-    {
-      _lcdDisplay->print(F(" "));
-    }
-  } else
+    startCol = (_cols - strlen(str)) / 2;
+    printChar = strlen(str);
+  }
+
+  _lcdDisplay->setCursor(startCol, line);
+  
+  for (uint8_t i = 0; i < printChar; i++)
   {
-    _lcdDisplay->print(str);
+    _lcdDisplay->write(str[i]);
   }
 }

--- a/src/MF_Modules/MFLCDDisplay.cpp
+++ b/src/MF_Modules/MFLCDDisplay.cpp
@@ -82,13 +82,19 @@ void MFLCDDisplay::test()
 void MFLCDDisplay::_printCentered(const char *str, uint8_t line)
 {
   _lcdDisplay->setCursor(0, line);
-  for (byte c = 0; c != ((_cols - strlen(str)) / 2); c++)
+  if (_cols > strlen(str))
   {
-    _lcdDisplay->print(F(" "));
-  }
-  _lcdDisplay->print(str);
-  for (byte c = 0; c != ((_cols - strlen(str)) / 2); c++)
+    for (byte c = 0; c != ((_cols - strlen(str)) / 2); c++)
+    {
+      _lcdDisplay->print(F(" "));
+    }
+    _lcdDisplay->print(str);
+    for (byte c = 0; c != ((_cols - strlen(str)) / 2); c++)
+    {
+      _lcdDisplay->print(F(" "));
+    }
+  } else
   {
-    _lcdDisplay->print(F(" "));
+    _lcdDisplay->print(str);
   }
 }


### PR DESCRIPTION
Check if string to be printed is longer than available columns. If so an "overflow" of 'c' happens and a lot of spaces are printed to the LCD which seems to crash the Arduino. By checking this condition and not printing spaces this crash is avoided.

I thought some time to check this in the LiquidCrystal_I2C library, but that would mean a lot of modifications as the column is not tracked there. The test() function here is the only place where this could happen so it's easier to make the modifications here.

Fixes #158 