### PR TITLE
Increase device limits on the Uno

### DIFF
--- a/_Boards/Atmel/Board_Uno/MFBoards.h
+++ b/_Boards/Atmel/Board_Uno/MFBoards.h
@@ -24,14 +24,14 @@
 #endif
 
 //#define MODULE_MAX_PINS 13
-#define MAX_OUTPUTS 8
-#define MAX_BUTTONS 8
+#define MAX_OUTPUTS 18
+#define MAX_BUTTONS 18
 #define MAX_LEDSEGMENTS 1
 #define MAX_ENCODERS 3
 #define MAX_STEPPERS 2
 #define MAX_MFSERVOS 2
 #define MAX_MFLCD_I2C 2
-#define MAX_ANALOG_INPUTS 3
+#define MAX_ANALOG_INPUTS 6
 #define MAX_OUTPUT_SHIFTERS 2
 #define MAX_INPUT_SHIFTERS 2
 


### PR DESCRIPTION
Fixes #161

## Description of changes

* Set max button count to 18
* Set max output count to 18
* Set max analog input count to 6