### PR TITLE
Config gets not "resetted" if InputShifter is deactivated

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -146,9 +146,9 @@ void resetConfig()
 #endif
 #if MF_INPUT_SHIFTER_SUPPORT == 1
     InputShifter::Clear();
+#endif
     configLength    = 0;
     configActivated = false;
-#endif
 }
 
 void OnResetConfig()

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -147,6 +147,9 @@ void resetConfig()
 #if MF_INPUT_SHIFTER_SUPPORT == 1
     InputShifter::Clear();
 #endif
+#if MF_DIGIN_MUX_SUPPORT == 1
+    DigInMux::Clear();
+#endif
     configLength    = 0;
     configActivated = false;
 }


### PR DESCRIPTION
Fixes #170

configLenght=0 and configActivated=false must not be encapsulated within MF_INPUT_SHIFTER_SUPPORTT==1
