### PR TITLE
Increase number of encoders for Uno and ProMicro

### DIFF
--- a/_Boards/Atmel/Board_ProMicro/MFBoards.h
+++ b/_Boards/Atmel/Board_ProMicro/MFBoards.h
@@ -40,7 +40,7 @@
 #define MAX_OUTPUTS         18
 #define MAX_BUTTONS         18
 #define MAX_LEDSEGMENTS     1
-#define MAX_ENCODERS        5
+#define MAX_ENCODERS        9
 #define MAX_STEPPERS        3
 #define MAX_MFSERVOS        3
 #define MAX_MFLCD_I2C       2

--- a/_Boards/Atmel/Board_Uno/MFBoards.h
+++ b/_Boards/Atmel/Board_Uno/MFBoards.h
@@ -39,7 +39,7 @@
 #define MAX_OUTPUTS         18
 #define MAX_BUTTONS         18
 #define MAX_LEDSEGMENTS     1
-#define MAX_ENCODERS        3
+#define MAX_ENCODERS        9
 #define MAX_STEPPERS        2
 #define MAX_MFSERVOS        2
 #define MAX_MFLCD_I2C       2


### PR DESCRIPTION
The max. number of encoders is increased to 9 for Uno and ProMicro. All available 18 Pins can be used for encoders.

Fixes #180
