### PR TITLE
platformio.ini uses deprecated `src_filter`

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,7 @@ build_flags =
 	-I./src/MF_Servo
 	-I./src/MF_Stepper
 	-I./src/MF_Modules
-src_filter =
+build_src_filter =
 	+<*>
 extra_scripts =
 	pre:get_version.py
@@ -57,8 +57,8 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Mega
-src_filter = 
-	${env.src_filter}
+build_src_filter = 
+	${env.build_src_filter}
 	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}	
@@ -74,8 +74,8 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_ProMicro
-src_filter = 
-	${env.src_filter}
+build_src_filter = 
+	${env.build_src_filter}
 	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}	
@@ -92,8 +92,8 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Uno
-src_filter = 
-	${env.src_filter}
+build_src_filter = 
+	${env.build_src_filter}
 	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}	


### PR DESCRIPTION
To avoid warning of deprecated function replace src_filter by build_src_filter

Fixes #184