### PR TITLE
Optimization of MFEEPROM class

### DIFF
--- a/src/MF_Modules/MFEEPROM.cpp
+++ b/src/MF_Modules/MFEEPROM.cpp
@@ -22,8 +22,8 @@ uint16_t MFEEPROM::get_length(void)
 
 bool MFEEPROM::read_block(uint16_t adr, char data[], uint16_t len)
 {
+    if (adr + len > _eepromLength) return false;
     for (uint16_t i = 0; i < len; i++) {
-        if (adr + len >= _eepromLength) return false;
         data[i] = read_char(adr + i);
     }
     return true;

--- a/src/MF_Modules/MFEEPROM.cpp
+++ b/src/MF_Modules/MFEEPROM.cpp
@@ -31,8 +31,8 @@ bool MFEEPROM::read_block(uint16_t adr, char data[], uint16_t len)
 
 bool MFEEPROM::write_block(uint16_t adr, char data[], uint16_t len)
 {
+    if (adr + len > _eepromLength) return false;
     for (uint16_t i = 0; i < len; i++) {
-        if (adr + i >= _eepromLength) return false;
         EEPROM.put(adr + i, data[i]);
     }
     return true;

--- a/src/MF_Modules/MFEEPROM.cpp
+++ b/src/MF_Modules/MFEEPROM.cpp
@@ -8,41 +8,47 @@
 #include "MFEEPROM.h"
 #include <EEPROM.h>
 
-MFEEPROM::MFEEPROM()
+MFEEPROM::MFEEPROM() {}
+
+void MFEEPROM::init(void)
 {
-    eepromLength = EEPROM.length();
+    _eepromLength = EEPROM.length();
 }
 
 uint16_t MFEEPROM::get_length(void)
 {
-    return eepromLength;
+    return _eepromLength;
 }
 
-void MFEEPROM::read_block(uint16_t adr, char data[], uint16_t len)
+bool MFEEPROM::read_block(uint16_t adr, char data[], uint16_t len)
 {
     for (uint16_t i = 0; i < len; i++) {
+        if (adr + len >= _eepromLength) return false;
         data[i] = read_char(adr + i);
     }
+    return true;
 }
 
-void MFEEPROM::write_block(uint16_t adr, char data[], uint16_t len)
+bool MFEEPROM::write_block(uint16_t adr, char data[], uint16_t len)
 {
-    if (adr + len >= eepromLength) return;
     for (uint16_t i = 0; i < len; i++) {
+        if (adr + i >= _eepromLength) return false;
         EEPROM.put(adr + i, data[i]);
     }
+    return true;
 }
 
 char MFEEPROM::read_char(uint16_t adr)
 {
-    if (adr >= eepromLength) return 0;
+    if (adr >= _eepromLength) return 0;
     return EEPROM.read(adr);
 }
 
-void MFEEPROM::write_byte(uint16_t adr, char data)
+bool MFEEPROM::write_byte(uint16_t adr, char data)
 {
-    if (adr >= eepromLength) return;
+    if (adr >= _eepromLength) return false;
     EEPROM.put(adr, data);
+    return true;
 }
 
 // MFEEPROM.cpp

--- a/src/MF_Modules/MFEEPROM.h
+++ b/src/MF_Modules/MFEEPROM.h
@@ -13,14 +13,15 @@ class MFEEPROM
 
 public:
     MFEEPROM();
+    void     init(void);
     uint16_t get_length(void);
-    void     read_block(uint16_t addr, char data[], uint16_t len);
-    void     write_block(uint16_t addr, char data[], uint16_t len);
+    bool     read_block(uint16_t addr, char data[], uint16_t len);
+    bool     write_block(uint16_t addr, char data[], uint16_t len);
     char     read_char(uint16_t adr);
-    void     write_byte(uint16_t adr, char data);
+    bool     write_byte(uint16_t adr, char data);
 
 private:
-    uint16_t eepromLength = 0;
+    uint16_t _eepromLength = 0;
 };
 
 // MFEEPROM.h

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -8,6 +8,7 @@
 #include "mobiflight.h"
 #include "Button.h"
 #include "Encoder.h"
+#include "MFEEPROM.h"
 #if MF_ANALOG_SUPPORT == 1
 #include "Analog.h"
 #endif
@@ -68,6 +69,8 @@ typedef struct {
 } lastUpdate_t;
 
 lastUpdate_t lastUpdate;
+
+extern MFEEPROM MFeeprom;
 
 void initPollIntervals(void)
 {
@@ -145,6 +148,7 @@ void ResetBoard()
 void setup()
 {
     Serial.begin(115200);
+    MFeeprom.init();
     attachCommandCallbacks();
     cmdMessenger.printLfCr();
     ResetBoard();


### PR DESCRIPTION
1. Like @GioCC always proposed, read/write block and write byte returns true or false (not used for now)
2. private variable `eepromLength ` is cahnged to `_eepromLength ` like in other MF classes.
3. If last eeprom location was addressed at read/write block complete block was not written/read
4. `MFEEPROM `needs separate `init()` for C++ compliance. `MFEEPROM `and `EEPROM `are global classes, and "correct" order of constructors can not be ensured. This is more a relevant for additional hardware/frameworks, but it might also a topic for the  future.

I am also fine if @GioCC includes it in his PR #175 (some are already included).

Fixes #186

