### PR TITLE
Add firmware debug printouts to log in the UI

### DIFF
--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -80,7 +80,7 @@ void attachCommandCallbacks()
 #endif
 
 #ifdef DEBUG2CMDMESSENGER
-    cmdMessenger.sendCmd(kStatus, F("Attached callbacks"));
+    cmdMessenger.sendCmd(kDebug, F("Attached callbacks"));
 #endif
 }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -93,7 +93,7 @@ bool readConfigLength()
 void loadConfig()
 {
 #ifdef DEBUG2CMDMESSENGER
-    cmdMessenger.sendCmd(kStatus, F("Load config"));
+    cmdMessenger.sendCmd(kDebug, F("Load config"));
 #endif
     if (readConfigLength()) {
         readConfig();
@@ -104,7 +104,7 @@ void loadConfig()
 void OnSetConfig()
 {
 #ifdef DEBUG2CMDMESSENGER
-    cmdMessenger.sendCmd(kStatus, F("Setting config start"));
+    cmdMessenger.sendCmd(kDebug, F("Setting config start"));
 #endif
     setLastCommandMillis();
     char   *cfg    = cmdMessenger.readStringArg();
@@ -117,7 +117,7 @@ void OnSetConfig()
     } else
         cmdMessenger.sendCmd(kStatus, -1); // last successfull saving block is already NULL terminated, nothing more todo
 #ifdef DEBUG2CMDMESSENGER
-    cmdMessenger.sendCmd(kStatus, F("Setting config end"));
+    cmdMessenger.sendCmd(kDebug, F("Setting config end"));
 #endif
 }
 

--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -36,7 +36,7 @@ namespace Analog
         MFAnalog::attachHandler(handlerOnAnalogChange);
         analogRegistered++;
     #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added analog device "));
+        cmdMessenger.sendCmd(kDebug, F("Added analog device "));
     #endif
     }
 
@@ -44,7 +44,7 @@ namespace Analog
     {
         analogRegistered = 0;
     #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared analog devices"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared analog devices"));
     #endif
     }
 

--- a/src/MF_Button/Button.cpp
+++ b/src/MF_Button/Button.cpp
@@ -35,7 +35,7 @@ namespace Button
         MFButton::attachHandler(handlerOnButton);
         buttonsRegistered++;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added button ") /* + name */);
+        cmdMessenger.sendCmd(kDebug, F("Added button ") /* + name */);
 #endif
     }
 
@@ -43,7 +43,7 @@ namespace Button
     {
         buttonsRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared buttons"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared buttons"));
 #endif
     }
 

--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -39,7 +39,7 @@ namespace DigInMux
         digInMuxRegistered++;
 
 #ifdef DEBUG2MSG
-        cmdMessenger.sendCmd(kStatus, F("Added digital input MUX"));
+        cmdMessenger.sendCmd(kDebug, F("Added digital input MUX"));
 #endif
     }
 
@@ -50,7 +50,7 @@ namespace DigInMux
         }
         digInMuxRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared dig. input Muxes"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared dig. input Muxes"));
 #endif
     }
 

--- a/src/MF_Encoder/Encoder.cpp
+++ b/src/MF_Encoder/Encoder.cpp
@@ -36,7 +36,7 @@ namespace Encoder
         MFEncoder::attachHandler(handlerOnEncoder);
         encodersRegistered++;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added encoder"));
+        cmdMessenger.sendCmd(kDebug, F("Added encoder"));
 #endif
     }
 
@@ -44,7 +44,7 @@ namespace Encoder
     {
         encodersRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared encoders"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared encoders"));
 #endif
     }
 

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -37,7 +37,7 @@ namespace InputShifter
         MFInputShifter::attachHandler(handlerInputShifterOnChange);
         inputShiftersRegistered++;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added input shifter"));
+        cmdMessenger.sendCmd(kDebug, F("Added input shifter"));
 #endif
     }
 
@@ -48,7 +48,7 @@ namespace InputShifter
         }
         inputShiftersRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared input shifter"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared input shifter"));
 #endif
     }
 

--- a/src/MF_LCDDisplay/LCDDisplay.cpp
+++ b/src/MF_LCDDisplay/LCDDisplay.cpp
@@ -27,7 +27,7 @@ namespace LCDDisplay
         lcd_I2C[lcd_12cRegistered]->attach(address, cols, lines);
         lcd_12cRegistered++;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added lcdDisplay"));
+        cmdMessenger.sendCmd(kDebug, F("Added lcdDisplay"));
 #endif
     }
 
@@ -38,7 +38,7 @@ namespace LCDDisplay
         }
         lcd_12cRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared lcdDisplays"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared lcdDisplays"));
 #endif
     }
 

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -26,7 +26,7 @@ namespace Output
         outputs[outputsRegistered] = new (allocateMemory(sizeof(MFOutput))) MFOutput(pin);
         outputsRegistered++;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added output"));
+        cmdMessenger.sendCmd(kDebug, F("Added output"));
 #endif
     }
 
@@ -34,7 +34,7 @@ namespace Output
     {
         outputsRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared outputs"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared outputs"));
 #endif
     }
 

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -28,7 +28,7 @@ namespace OutputShifter
         outputShifterRegistered++;
 
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added Output Shifter"));
+        cmdMessenger.sendCmd(kDebug, F("Added Output Shifter"));
 #endif
     }
 
@@ -40,7 +40,7 @@ namespace OutputShifter
 
         outputShifterRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared Output Shifter"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared Output Shifter"));
 #endif
     }
 

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -27,7 +27,7 @@ namespace LedSegment
         ledSegments[ledSegmentsRegistered]->attach(dataPin, csPin, clkPin, numDevices, brightness); // lc is our object
         ledSegmentsRegistered++;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added Led Segment"));
+        cmdMessenger.sendCmd(kDebug, F("Added Led Segment"));
 #endif
     }
 
@@ -38,7 +38,7 @@ namespace LedSegment
         }
         ledSegmentsRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared segments"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared segments"));
 #endif
     }
 

--- a/src/MF_Servo/Servos.cpp
+++ b/src/MF_Servo/Servos.cpp
@@ -27,7 +27,7 @@ namespace Servos
         servos[servosRegistered]->attach(pin, true);
         servosRegistered++;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added servos"));
+        cmdMessenger.sendCmd(kDebug, F("Added servos"));
 #endif
     }
 
@@ -38,7 +38,7 @@ namespace Servos
         }
         servosRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared servos"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared servos"));
 #endif
     }
 

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -13,7 +13,7 @@ namespace Stepper
     MFStepper *steppers[MAX_STEPPERS];
     uint8_t    steppersRegistered = 0;
 
-    void  Add(int pin1, int pin2, int pin3, int pin4, int btnPin1)
+    void Add(int pin1, int pin2, int pin3, int pin4, int btnPin1)
     {
         if (steppersRegistered == MAX_STEPPERS)
             return;
@@ -37,7 +37,7 @@ namespace Stepper
         steppersRegistered++;
 
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Added stepper"));
+        cmdMessenger.sendCmd(kDebug, F("Added stepper"));
 #endif
     }
 
@@ -48,7 +48,7 @@ namespace Stepper
         }
         steppersRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kStatus, F("Cleared steppers"));
+        cmdMessenger.sendCmd(kDebug, F("Cleared steppers"));
 #endif
     }
 

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -18,7 +18,7 @@ char    *allocateMemory(uint8_t size)
         return nullptr;
     }
 #ifdef DEBUG2CMDMESSENGER
-    cmdMessenger.sendCmdStart(kStatus);
+    cmdMessenger.sendCmdStart(kDebug);
     cmdMessenger.sendCmdArg(F("BufferUsage"));
     cmdMessenger.sendCmdArg(nextPointer);
     cmdMessenger.sendCmdEnd();

--- a/src/commandmessenger.h
+++ b/src/commandmessenger.h
@@ -43,7 +43,7 @@ enum {
     kAnalogChange,         // 28
     kInputShifterChange,   // 29
     kDigInMuxChange,       // 30
-    kDebug = 0xFF          // 255 -> for Debug print later, changes in UI are required
+    kDebug = 0xFF          // 255
 };
 
 void                attachCommandCallbacks();

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -111,9 +111,9 @@ void SetPowerSavingMode(bool state)
 
 #ifdef DEBUG2CMDMESSENGER
     if (state)
-        cmdMessenger.sendCmd(kStatus, F("On"));
+        cmdMessenger.sendCmd(kDebug, F("On"));
     else
-        cmdMessenger.sendCmd(kStatus, F("Off"));
+        cmdMessenger.sendCmd(kDebug, F("Off"));
 #endif
 }
 


### PR DESCRIPTION
Debug prints send via the commandmessenger are marked with kStatus. This is changed to KDebug to seperate them from status messages.
With changes in the UI the will appear if loglevel is debug.

Fixes #188
