### PR TITLE
Remove link to Open in VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # MobiFlight-FirmwareSource
 
-[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/MobiFlight/MobiFlight-FirmwareSource)
-
 PlatformIO version of the MobiFlight firmware source.
 
 To build:


### PR DESCRIPTION
## Description of changes

Fixes #195

Remove the open in vscode line since nobody likely ever used it and the image was broken.