### PR TITLE
Improve getting correct device infos for connector from Mega

### DIFF
--- a/src/MF_Button/MFButton.cpp
+++ b/src/MF_Button/MFButton.cpp
@@ -12,8 +12,8 @@ MFButton::MFButton(uint8_t pin, const char *name)
 {
     _pin   = pin;
     _name  = name;
-    _state = 1;
-    pinMode(_pin, INPUT_PULLUP); // set pin to input
+    pinMode(_pin, INPUT_PULLUP);    // set pin to input
+    _state = digitalRead(_pin);     // initialize on actual status
 }
 
 void MFButton::update()

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -33,7 +33,6 @@ namespace InputShifter
         }
         inputShifters[inputShiftersRegistered] = new (allocateMemory(sizeof(MFInputShifter))) MFInputShifter;
         inputShifters[inputShiftersRegistered]->attach(latchPin, clockPin, dataPin, modules, name);
-        inputShifters[inputShiftersRegistered]->clear();
         MFInputShifter::attachHandler(handlerInputShifterOnChange);
         inputShiftersRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_InputShifter/MFInputShifter.h
+++ b/src/MF_InputShifter/MFInputShifter.h
@@ -40,7 +40,7 @@ private:
     uint8_t                  _dataPin;     // SDO (data) pin
     uint8_t                  _moduleCount; // Number of 8 bit modules in series.
     bool                     _initialized = false;
-    uint8_t                  _lastState[MAX_CHAINED_INPUT_SHIFTERS];
+    uint8_t                  _lastState[MAX_CHAINED_INPUT_SHIFTERS] = {0};
 
     void                     detectChanges(uint8_t lastState, uint8_t currentState, uint8_t module);
     void                     trigger(uint8_t pin, bool state);

--- a/src/MF_InputShifter/MFInputShifter.h
+++ b/src/MF_InputShifter/MFInputShifter.h
@@ -44,7 +44,6 @@ private:
 
     void                     detectChanges(uint8_t lastState, uint8_t currentState, uint8_t module);
     void                     trigger(uint8_t pin, bool state);
-    void                     clearLastState();
     static inputShifterEvent _inputHandler;
 };
 


### PR DESCRIPTION
## Description of changes
Buttons and input shifters are initialized with the actual status of inputs.
This avoids serial messages an startup due to changed status of inputs in case they are closed (ON).

Fixes #200
