### PR TITLE
Removed "Lazy" mode from Multiplexer code (#204)

### DIFF
--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -15,7 +15,7 @@ namespace DigInMux
     MFDigInMux *digInMux[MAX_DIGIN_MUX];
     uint8_t     digInMuxRegistered = 0;
 
-    void        handlerOnDigInMux(uint8_t eventId, uint8_t channel, const char *name)
+    void handlerOnDigInMux(uint8_t eventId, uint8_t channel, const char *name)
     {
         cmdMessenger.sendCmdStart(kDigInMuxChange);
         cmdMessenger.sendCmdArg(name);
@@ -24,7 +24,7 @@ namespace DigInMux
         cmdMessenger.sendCmdEnd();
     };
 
-    void Add(uint8_t dataPin, uint8_t nRegs, char const *name, bool mode)
+    void Add(uint8_t dataPin, uint8_t nRegs, char const *name)
     {
         if (digInMuxRegistered == MAX_DIGIN_MUX)
             return;
@@ -33,7 +33,6 @@ namespace DigInMux
         digInMux[digInMuxRegistered] = dip;
         dip->attach(dataPin, (nRegs == 1), name);
         dip->clear();
-        dip->setLazyMode(mode == MFDigInMux::MUX_MODE_LAZY);
         // MFDigInMux::setMux(&MUX);
         MFDigInMux::attachHandler(handlerOnDigInMux);
         digInMuxRegistered++;

--- a/src/MF_DigInMux/DigInMux.h
+++ b/src/MF_DigInMux/DigInMux.h
@@ -10,7 +10,7 @@
 
 namespace DigInMux
 {
-    void Add(uint8_t dataPin, uint8_t nRegs, char const *name = "DigInMux", bool mode = MFDigInMux::MUX_MODE_FAST);
+    void Add(uint8_t dataPin, uint8_t nRegs, char const *name = "DigInMux");
     void Clear();
     void read();
     void OnTrigger();

--- a/src/MF_DigInMux/MFDigInMux.cpp
+++ b/src/MF_DigInMux/MFDigInMux.cpp
@@ -8,7 +8,7 @@
 #include "MFDigInMux.h"
 #include "MFMuxDriver.h"
 
-MFMuxDriver  *MFDigInMux::_MUX;
+MFMuxDriver *MFDigInMux::_MUX;
 
 MuxDigInEvent MFDigInMux::_inputHandler = NULL;
 
@@ -17,7 +17,6 @@ MFDigInMux::MFDigInMux(void)
     _MUX   = NULL;
     _name  = "MUXDigIn";
     _flags = 0x00;
-    setLazyMode(MUX_MODE_FAST);
     clear();
 }
 
@@ -26,7 +25,6 @@ MFDigInMux::MFDigInMux(MFMuxDriver *MUX, const char *name)
 {
     if (MUX) _MUX = MUX;
     _flags = 0x00;
-    setLazyMode(MUX_MODE_FAST);
     clear();
 }
 
@@ -64,89 +62,44 @@ void MFDigInMux::detach()
 // changed from the previously read state.
 void MFDigInMux::update()
 {
-    poll(DO_TRIGGER, bitRead(_flags, MUX_LAZY));
+    poll(true);
 }
 
 // Helper function for update() and retrigger()
-void MFDigInMux::poll(bool doTrigger, bool isLazy)
+void MFDigInMux::poll(bool detect)
 {
     if (!_MUX) return;
 
-    // Meaning of "Lazy mode" flag
-    // ===========================
-    //
-    // Lazy mode ON:
-    // MUX selector is set externally, normally at main loop level
-    // (incremented sequentially at each pass)
-    // Individual modules work in one of two ways:
-    // 1. they must have an associate channel number (which may also be "any"),
-    //    and only execute if that matches the current channel;
-    // 2. account for current channel number in their internal working
-    //    (e.g. for digital inputs, "place input bit in position #n").
-    //
-    // Lazy mode OFF (default):
-    // Every block using the multiplexer sets its own selector value (or span of values).
-    // MUX selector can have any value upon entry; it is saved and restored before exit.
-    //
-    // Each block can use its preferred mode, and blocks of both types can co-exist.
+    uint8_t          selMax       = (bitRead(_flags, MUX_HALFSIZE) ? 8 : 16);
+    uint16_t         currentState = 0x0000;
+    volatile uint8_t pinVal;
 
-    uint8_t selMax = (bitRead(_flags, MUX_HALFSIZE) ? 8 : 16);
+    _MUX->saveChannel();
+    for (uint8_t sel = selMax; sel > 0; sel--) {
+        _MUX->setChannel(sel - 1);
 
-    if (!isLazy) {
+        // Allow the output to settle from voltage transients:
+        // transients towards 0 (GND) are negligible, but transients towards 1 (Vcc)
+        // require a pullup to charge parasitic capacities.
+        // These are examples of delay times measured for 0->1 transitions with different pull-ups:
+        // integrated PU -> 1.4us
+        // external, 10k -> 400ns
+        // external, 4k7 -> 250ns
+        // A digitalRead() takes about 5us, therefore even the integrated pullup should be sufficient;
+        // for added safety, we perform one more (useless) digitalRead().
+        // NB An external pullup (10k or 4k7) is recommended anyway for better interference immunity.
 
-        // "Fast" read:
-        // scan all inputs right away
+        pinVal = digitalRead(_dataPin);
+        pinVal = digitalRead(_dataPin);
+        // delayMicroseconds(5);  // This is overkill
+        currentState <<= 1;
+        currentState |= (pinVal ? 1 : 0);
+    }
+    _MUX->restoreChannel(); // tidy up
 
-        uint16_t         currentState = 0x0000;
-        volatile uint8_t pinVal;
-
-        _MUX->saveChannel();
-        for (uint8_t sel = selMax; sel > 0; sel--) {
-            _MUX->setChannel(sel - 1);
-
-            // Allow the output to settle from voltage transients:
-            // transients towards 0 (GND) are negligible, but transients towards 1 (Vcc)
-            // require a pullup to charge parasitic capacities.
-            // These are examples of delay times measured for 0->1 transitions with different pull-ups:
-            // integrated PU -> 1.4us
-            // external, 10k -> 400ns
-            // external, 4k7 -> 250ns
-            // A digitalRead() takes about 5us, therefore even the integrated pullup should be sufficient;
-            // for added safety, we perform one more (useless) digitalRead().
-            // NB An external pullup (10k or 4k7) is recommended anyway for better interference immunity.
-
-            pinVal = digitalRead(_dataPin);
-            pinVal = digitalRead(_dataPin);
-            // delayMicroseconds(5);  // This is overkill
-            currentState <<= 1;
-            currentState |= (pinVal ? 1 : 0);
-        }
-        _MUX->restoreChannel(); // tidy up
-
-        if (_lastState != currentState) {
-            if (doTrigger) detectChanges(_lastState, currentState);
-            _lastState = currentState;
-        }
-
-    } else {
-
-        // "Lazy" read:
-        // read one more channel every time the method is invoked
-        // (the corresponding event, if any, is generated immediately).
-        // Relies on the MuxDriver to be set externally by the caller
-        // (typically incremented at every main loop iteration).
-
-        bool     chVal = (digitalRead(_dataPin) ? true : false);
-        uint8_t  ch    = _MUX->getChannel() % selMax;
-        uint16_t msk   = (0x0001 << ch);
-
-        if (((_lastState & msk) != 0) != chVal) trigger(ch, chVal);
-
-        if (chVal) {
-            _lastState |= msk;
-        } else {
-            _lastState &= ~msk;
-        }
+    if (_lastState != currentState) {
+        if (detect) detectChanges(_lastState, currentState);
+        _lastState = currentState;
     }
 }
 
@@ -174,7 +127,7 @@ void MFDigInMux::retrigger()
     // The current state for all attached modules is stored,
     // so future update() calls will work off whatever was read by the
     // retrigger flow.
-    poll(DONT_TRIGGER, false); // just read, do not retrigger
+    poll(false); // just read, do not retrigger
 
     // Pass 1/2: Trigger all the 'off' inputs (released buttons) first
     detectChanges(0x0000, _lastState);
@@ -201,15 +154,6 @@ void MFDigInMux::attachHandler(MuxDigInEvent newHandler)
 void MFDigInMux::clear()
 {
     _lastState = 0;
-}
-
-void MFDigInMux::setLazyMode(bool mode)
-{
-    if (mode) {
-        bitSet(_flags, MUX_LAZY);
-    } else {
-        bitClear(_flags, MUX_LAZY);
-    }
 }
 
 // MFDigInMux.cpp

--- a/src/MF_DigInMux/MFDigInMux.cpp
+++ b/src/MF_DigInMux/MFDigInMux.cpp
@@ -45,8 +45,7 @@ void MFDigInMux::attach(uint8_t dataPin, bool halfSize, char const *name)
     bitSet(_flags, MUX_INITED);
 
     // Initialize all inputs with current status
-    poll(DONT_TRIGGER, bitRead(_flags, MUX_LAZY));
-
+    poll(DONT_TRIGGER);
 }
 
 void MFDigInMux::detach()
@@ -62,11 +61,11 @@ void MFDigInMux::detach()
 // changed from the previously read state.
 void MFDigInMux::update()
 {
-    poll(true);
+    poll(DO_TRIGGER);
 }
 
 // Helper function for update() and retrigger()
-void MFDigInMux::poll(bool detect)
+void MFDigInMux::poll(bool doTrigger)
 {
     if (!_MUX) return;
 
@@ -98,7 +97,7 @@ void MFDigInMux::poll(bool detect)
     _MUX->restoreChannel(); // tidy up
 
     if (_lastState != currentState) {
-        if (detect) detectChanges(_lastState, currentState);
+        if (doTrigger) detectChanges(_lastState, currentState);
         _lastState = currentState;
     }
 }
@@ -127,7 +126,7 @@ void MFDigInMux::retrigger()
     // The current state for all attached modules is stored,
     // so future update() calls will work off whatever was read by the
     // retrigger flow.
-    poll(false); // just read, do not retrigger
+    poll(DONT_TRIGGER); // just read, do not retrigger
 
     // Pass 1/2: Trigger all the 'off' inputs (released buttons) first
     detectChanges(0x0000, _lastState);

--- a/src/MF_DigInMux/MFDigInMux.h
+++ b/src/MF_DigInMux/MFDigInMux.h
@@ -21,27 +21,21 @@ enum {
 class MFDigInMux
 {
 public:
-    enum { MUX_MODE_FAST = 0,
-           MUX_MODE_LAZY = 1,
-    };
-
     MFDigInMux(void);
     MFDigInMux(MFMuxDriver *MUX, const char *name);
     static void setMux(MFMuxDriver *MUX);
     static void attachHandler(MuxDigInEvent newHandler);
 
-    void        attach(uint8_t dataPin, bool halfSize, char const *name);
-    void        detach();
-    void        clear();
-    void        retrigger();
-    void        update();
-    void        setLazyMode(bool mode);
-    uint16_t    getValues(void) { return _lastState; }
+    void     attach(uint8_t dataPin, bool halfSize, char const *name);
+    void     detach();
+    void     clear();
+    void     retrigger();
+    void     update();
+    uint16_t getValues(void) { return _lastState; }
 
 private:
     enum { MUX_INITED   = 0,
            MUX_HALFSIZE = 1,
-           MUX_LAZY     = 2,
     };
 
     enum { DONT_TRIGGER = 0,
@@ -50,14 +44,14 @@ private:
     static MFMuxDriver  *_MUX;
     static MuxDigInEvent _inputHandler;
 
-    const char          *_name;
-    uint8_t              _dataPin; // Data pin - MUX common, input to AVR
-    uint8_t              _flags;
-    uint16_t             _lastState;
+    const char *_name;
+    uint8_t     _dataPin; // Data pin - MUX common, input to AVR
+    uint8_t     _flags;
+    uint16_t    _lastState;
 
-    void                 poll(bool detect, bool lazy);
-    void                 detectChanges(uint16_t lastState, uint16_t currentState);
-    void                 trigger(uint8_t channel, bool state);
+    void poll(bool detect);
+    void detectChanges(uint16_t lastState, uint16_t currentState);
+    void trigger(uint8_t channel, bool state);
 };
 
 // MFDigInMux.h


### PR DESCRIPTION
## Description of changes
Fixes #204
- Removed `Lazy` code branch and `mode` argument from `MFDigInMux::poll()`
- Removed setLazyMode() (and related enum) from `MFDigInMux.*`
- Removed `mode` argument from `DigInMux::Add`
