### PR TITLE
Change constant for averaging buffer size of analog inputs (#211)

### DIFF
--- a/src/MF_Analog/MFAnalog.h
+++ b/src/MF_Analog/MFAnalog.h
@@ -8,8 +8,11 @@
 
 #include <Arduino.h>
 
-#define ADC_MAX_AVERAGE      8 // must be 2^n
-#define ADC_MAX_AVERAGE_LOG2 3 // please calculate LOG2(ADC_MAX_AVERAGE)
+// Following value defines the buffer size for samples; the larger the buffer,
+// the smoother the response (and the larger the delay).
+// Buffer size is 2^ADC_MAX_AVERAGE_LOG2: 3 -> 8 samples, 4 -> 16 samples etc.
+#define ADC_MAX_AVERAGE_LOG2 3
+#define ADC_MAX_AVERAGE      (1 << ADC_MAX_AVERAGE_LOG2)
 
 extern "C" {
 // callback functions


### PR DESCRIPTION
## Description of changes
Fixes #211

Changed the way of defining the size of the buffer (no change in value)
Added comment 