### PR TITLE
add write block w/o length, renaming read_char

### DIFF
--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -78,7 +78,7 @@ void attachCommandCallbacks()
     cmdMessenger.attach(kSetLcdDisplayI2C, LCDDisplay::OnSet);
 #endif
 
-#if MF_OUTPUT_SHIFTER_SUPPORT
+#if MF_OUTPUT_SHIFTER_SUPPORT == 1
     cmdMessenger.attach(kSetShiftRegisterPins, OutputShifter::OnSet);
 #endif
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -466,7 +466,7 @@ void storeName()
 
 void restoreName()
 {
-    if (MFeeprom.read_char(MEM_OFFSET_NAME) != '#')
+    if (MFeeprom.read_byte(MEM_OFFSET_NAME) != '#')
         return;
 
     MFeeprom.read_block(MEM_OFFSET_NAME + 1, name, MEM_LEN_NAME - 1);

--- a/src/MF_Modules/MFEEPROM.cpp
+++ b/src/MF_Modules/MFEEPROM.cpp
@@ -6,7 +6,6 @@
 
 #include <Arduino.h>
 #include "MFEEPROM.h"
-#include <EEPROM.h>
 
 MFEEPROM::MFEEPROM() {}
 
@@ -20,34 +19,16 @@ uint16_t MFEEPROM::get_length(void)
     return _eepromLength;
 }
 
-bool MFEEPROM::read_block(uint16_t adr, char data[], uint16_t len)
-{
-    if (adr + len > _eepromLength) return false;
-    for (uint16_t i = 0; i < len; i++) {
-        data[i] = read_char(adr + i);
-    }
-    return true;
-}
-
-bool MFEEPROM::write_block(uint16_t adr, char data[], uint16_t len)
-{
-    if (adr + len > _eepromLength) return false;
-    for (uint16_t i = 0; i < len; i++) {
-        EEPROM.put(adr + i, data[i]);
-    }
-    return true;
-}
-
-char MFEEPROM::read_char(uint16_t adr)
+uint8_t MFEEPROM::read_byte(uint16_t adr)
 {
     if (adr >= _eepromLength) return 0;
     return EEPROM.read(adr);
 }
 
-bool MFEEPROM::write_byte(uint16_t adr, char data)
+bool MFEEPROM::write_byte(uint16_t adr, const uint8_t data)
 {
     if (adr >= _eepromLength) return false;
-    EEPROM.put(adr, data);
+    EEPROM.write(adr, data);
     return true;
 }
 

--- a/src/MF_Modules/MFEEPROM.h
+++ b/src/MF_Modules/MFEEPROM.h
@@ -6,22 +6,56 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <EEPROM.h>
 
 class MFEEPROM
 {
+private:
+    uint16_t _eepromLength = 0;
 
 public:
     MFEEPROM();
     void     init(void);
     uint16_t get_length(void);
-    bool     read_block(uint16_t addr, char data[], uint16_t len);
-    bool     write_block(uint16_t addr, char data[], uint16_t len);
-    char     read_char(uint16_t adr);
-    bool     write_byte(uint16_t adr, char data);
+    uint8_t read_byte(uint16_t adr);
+    bool write_byte(uint16_t adr, const uint8_t data);
 
-private:
-    uint16_t _eepromLength = 0;
+    template <typename T>
+    bool read_block(uint16_t adr, T &t)
+    {
+        if (adr + sizeof(T) > _eepromLength) return false;
+        EEPROM.get(adr, t);
+        return true;
+    }
+
+    template <typename T>
+    bool read_block(uint16_t adr, T &t, uint16_t len)
+    {
+        if (adr + len > _eepromLength) return false;
+        uint8_t *ptr = (uint8_t*) &t;
+        for (uint16_t i = 0; i < len; i++) {
+            *ptr++ = EEPROM.read(adr + i);
+        }
+        return true;
+    }
+
+    template <typename T>
+    const bool write_block(uint16_t adr, const T &t)
+    {
+        if (adr + sizeof(T) > _eepromLength) return false;
+        EEPROM.put(adr, t);
+        return true;
+    }
+
+    template <typename T>
+    const bool write_block(uint16_t adr, const T &t, uint16_t len)
+    {
+        if (adr + len > _eepromLength) return false;
+        for (uint16_t i = 0; i < len; i++) {
+            EEPROM.put(adr + i, t[i]);
+        }
+        return true;
+    }
 };
 
 // MFEEPROM.h


### PR DESCRIPTION
`read_char()` is renamed to `read_byte()` as mainly a byte is required.
Within `OnGetInfo()` a char is required to send the config via the command messenger, at this point `read_byte()` is casted.
Additional functions to save/read a complete array or struct. This could be helpfull for future use (e.g. parameters for an analog calibration should be in a struct and this struct should be saved to the EEPROM). These additional functions and the existing functions for reading/saving arrays with fixed lenght are moved to `EEPROM.h` in a template.

`storeName()` and `restoreName()` are cleaned up slightly

Fixes #221 
