### PR TITLE
faulty init on startup, check for available memory

### DIFF
--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -29,11 +29,14 @@ namespace DigInMux
         if (digInMuxRegistered == MAX_DIGIN_MUX)
             return;
         MFDigInMux *dip;
+        if (!FitInMemory(sizeof(MFDigInMux))) {
+            // Error Message to Connector
+            cmdMessenger.sendCmd(kStatus, F("DigInMux does not fit in Memory"));
+            return;
+        }
         dip                          = new (allocateMemory(sizeof(MFDigInMux))) MFDigInMux(&MUX, name);
         digInMux[digInMuxRegistered] = dip;
         dip->attach(dataPin, (nRegs == 1), name);
-        dip->clear();
-        // MFDigInMux::setMux(&MUX);
         MFDigInMux::attachHandler(handlerOnDigInMux);
         digInMuxRegistered++;
 


### PR DESCRIPTION
On startup the constructor for the digital input multiplexer is called and the status of each input gets initialized to the current status. With one of the next steps this status get be cleared again, so on startup serial messages could be generated due to status changes of the inputs.
Furthermore it is not checked like for the other devices if the digital input multiplexer fits into the device buffer.

Calling the clear() function is deleted.
Check if device fits into the device buffer is added.

Fixes #226 