### PR TITLE
Unique

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ lib_deps =
 	waspinator/AccelStepper @ 1.61
 	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4
 	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
+	ricaun/ArduinoUniqueID @ ^1.3.0
 build_flags =
 	-DMF_REDUCE_FUNCT_LEDCONTROL
 	-DMAXCALLBACKS=30

--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -78,7 +78,7 @@ void attachCommandCallbacks()
     cmdMessenger.attach(kSetLcdDisplayI2C, LCDDisplay::OnSet);
 #endif
 
-#if MF_OUTPUT_SHIFTER_SUPPORT
+#if MF_OUTPUT_SHIFTER_SUPPORT == 1
     cmdMessenger.attach(kSetShiftRegisterPins, OutputShifter::OnSet);
 #endif
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -447,15 +447,31 @@ void generateSerial(bool force)
     if (!force && serial[0] == 'I' && serial[1] == 'D') {
         sprintf(serial, "SN-");
         for (size_t i = 0; i < UniqueIDsize; i++) {
-            serial[3 + i] = UniqueID[i]; // ToDo: transfer Unique ID to a string
+            /*
+                        if (UniqueID[i] < 0x10) {
+                            sprintf(&serial[3 + i], "0");
+                            sprintf(&serial[3 + i + 1], "%X", UniqueID[i]);
+                        } else {
+                            sprintf(&serial[3 + i], "%X", UniqueID[i]);
+                        }
+            */
+            sprintf(&serial[3 + i * 2], "%2X", UniqueID[i]);
         }
         return;
     }
-    // A serial number was not generated so far on first start up
+    // A serial number was not generated so far on first start up or it is forced to generate a new one
     // So read the unique ID
     sprintf(serial, "SN-");
     for (size_t i = 0; i < UniqueIDsize; i++) {
-        serial[3 + i] = UniqueID[i]; // ToDo: transfer Unique ID to a string
+        /*
+                if (UniqueID[i] < 0x10) {
+                    sprintf(&serial[3 + i], "0");
+                    sprintf(&serial[3 + i + 1], "%X", UniqueID[i]);
+                } else {
+                    sprintf(&serial[3 + i], "%X", UniqueID[i]);
+                }
+        */
+        sprintf(&serial[3 + i * 2], "%2X", UniqueID[i]);
     }
     // and mark this in the eeprom
     MFeeprom.write_block(MEM_OFFSET_SERIAL, "ID", 2);

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -438,6 +438,7 @@ bool getStatusConfig()
 void generateSerial(bool force)
 {
     if (force) {
+#if defined(ARDUINO_ARCH_AVR)
         // A serial number is forced to generated from the user
         // It is very likely that the reason is a double serial number as the UniqueID for AVR's must not be Unique
         // so generate one acc. the old style and use millis() for seed
@@ -445,6 +446,7 @@ void generateSerial(bool force)
         sprintf(serial, "SN-%03x-", (unsigned int)random(4095));
         sprintf(&serial[7], "%03x", (unsigned int)random(4095));
         MFeeprom.write_block(MEM_OFFSET_SERIAL, serial, MEM_LEN_SERIAL);
+#endif
         return;
     }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -76,16 +76,15 @@ bool readConfigLength()
     uint16_t addreeprom = MEM_OFFSET_CONFIG;
     uint16_t length     = MFeeprom.get_length();
     configLength        = 0;
-    do {
-        temp = MFeeprom.read_char(addreeprom++);
+
+    while (MFeeprom.read_byte(addreeprom++) != 0x00) {
         configLength++;
         if (addreeprom > length) // abort if EEPROM size will be exceeded
         {
             cmdMessenger.sendCmd(kStatus, F("Loading config failed")); // text or "-1" like config upload?
             return false;
         }
-    } while (temp != 0x00); // reads until NULL
-    configLength--;
+    }
     return true;
 }
 
@@ -194,7 +193,7 @@ uint8_t readUintFromEEPROM(volatile uint16_t *addreeprom)
     char    params[4] = {0}; // max 3 (255) digits NULL terminated
     uint8_t counter   = 0;
     do {
-        params[counter++] = MFeeprom.read_char((*addreeprom)++);      // read character from eeprom and locate next buffer and eeprom location
+        params[counter++] = MFeeprom.read_byte((*addreeprom)++);      // read character from eeprom and locate next buffer and eeprom location
     } while (params[counter - 1] != '.' && counter < sizeof(params)); // reads until limiter '.' and for safety reason not more then size of params[]
     params[counter - 1] = 0x00;                                       // replace '.' by NULL to terminate the string
     return atoi(params);
@@ -206,7 +205,7 @@ bool readNameFromEEPROM(uint16_t *addreeprom, char *buffer, uint16_t *addrbuffer
 {
     char temp = 0;
     do {
-        temp                    = MFeeprom.read_char((*addreeprom)++); // read the first character
+        temp                    = MFeeprom.read_byte((*addreeprom)++); // read the first character
         buffer[(*addrbuffer)++] = temp;                                // save character and locate next buffer position
         if (*addrbuffer >= MEMLEN_NAMES_BUFFER) {                      // nameBuffer will be exceeded
             return false;                                              // abort copying from EEPROM to nameBuffer
@@ -222,7 +221,7 @@ bool readEndCommandFromEEPROM(uint16_t *addreeprom)
     char     temp   = 0;
     uint16_t length = MFeeprom.get_length();
     do {
-        temp = MFeeprom.read_char((*addreeprom)++);
+        temp = MFeeprom.read_byte((*addreeprom)++);
         if (*addreeprom > length) // abort if EEPROM size will be exceeded
             return false;
     } while (temp != ':'); // reads until limiter ':'
@@ -409,9 +408,9 @@ void OnGetConfig()
     setLastCommandMillis();
     cmdMessenger.sendCmdStart(kInfo);
     if (configLength > 0) {
-        cmdMessenger.sendCmdArg(MFeeprom.read_char(MEM_OFFSET_CONFIG));
+        cmdMessenger.sendCmdArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG));
         for (uint16_t i = 1; i < configLength; i++) {
-            cmdMessenger.sendArg(MFeeprom.read_char(MEM_OFFSET_CONFIG + i));
+            cmdMessenger.sendArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG + i));
         }
     }
     cmdMessenger.sendCmdEnd();
@@ -467,7 +466,7 @@ void storeName()
 
 void restoreName()
 {
-    if (MFeeprom.read_char(MEM_OFFSET_NAME) != '#')
+    if (MFeeprom.read_byte(MEM_OFFSET_NAME) != '#')
         return;
 
     MFeeprom.read_block(MEM_OFFSET_NAME + 1, name, MEM_LEN_NAME - 1);

--- a/src/MF_Analog/MFAnalog.h
+++ b/src/MF_Analog/MFAnalog.h
@@ -8,8 +8,11 @@
 
 #include <Arduino.h>
 
-#define ADC_MAX_AVERAGE      8 // must be 2^n
-#define ADC_MAX_AVERAGE_LOG2 3 // please calculate LOG2(ADC_MAX_AVERAGE)
+// Following value defines the buffer size for samples; the larger the buffer,
+// the smoother the response (and the larger the delay).
+// Buffer size is 2^ADC_MAX_AVERAGE_LOG2: 3 -> 8 samples, 4 -> 16 samples etc.
+#define ADC_MAX_AVERAGE_LOG2 3
+#define ADC_MAX_AVERAGE      (1 << ADC_MAX_AVERAGE_LOG2)
 
 extern "C" {
 // callback functions

--- a/src/MF_Modules/MFEEPROM.cpp
+++ b/src/MF_Modules/MFEEPROM.cpp
@@ -6,7 +6,6 @@
 
 #include <Arduino.h>
 #include "MFEEPROM.h"
-#include <EEPROM.h>
 
 MFEEPROM::MFEEPROM() {}
 
@@ -20,34 +19,16 @@ uint16_t MFEEPROM::get_length(void)
     return _eepromLength;
 }
 
-bool MFEEPROM::read_block(uint16_t adr, char data[], uint16_t len)
-{
-    if (adr + len > _eepromLength) return false;
-    for (uint16_t i = 0; i < len; i++) {
-        data[i] = read_char(adr + i);
-    }
-    return true;
-}
-
-bool MFEEPROM::write_block(uint16_t adr, char data[], uint16_t len)
-{
-    if (adr + len > _eepromLength) return false;
-    for (uint16_t i = 0; i < len; i++) {
-        EEPROM.put(adr + i, data[i]);
-    }
-    return true;
-}
-
-char MFEEPROM::read_char(uint16_t adr)
+uint8_t MFEEPROM::read_byte(uint16_t adr)
 {
     if (adr >= _eepromLength) return 0;
     return EEPROM.read(adr);
 }
 
-bool MFEEPROM::write_byte(uint16_t adr, char data)
+bool MFEEPROM::write_byte(uint16_t adr, const uint8_t data)
 {
     if (adr >= _eepromLength) return false;
-    EEPROM.put(adr, data);
+    EEPROM.write(adr, data);
     return true;
 }
 

--- a/src/MF_Modules/MFEEPROM.h
+++ b/src/MF_Modules/MFEEPROM.h
@@ -6,22 +6,56 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <EEPROM.h>
 
 class MFEEPROM
 {
+private:
+    uint16_t _eepromLength = 0;
 
 public:
     MFEEPROM();
     void     init(void);
     uint16_t get_length(void);
-    bool     read_block(uint16_t addr, char data[], uint16_t len);
-    bool     write_block(uint16_t addr, char data[], uint16_t len);
-    char     read_char(uint16_t adr);
-    bool     write_byte(uint16_t adr, char data);
+    uint8_t read_byte(uint16_t adr);
+    bool write_byte(uint16_t adr, const uint8_t data);
 
-private:
-    uint16_t _eepromLength = 0;
+    template <typename T>
+    bool read_block(uint16_t adr, T &t)
+    {
+        if (adr + sizeof(T) > _eepromLength) return false;
+        EEPROM.get(adr, t);
+        return true;
+    }
+
+    template <typename T>
+    bool read_block(uint16_t adr, T &t, uint16_t len)
+    {
+        if (adr + len > _eepromLength) return false;
+        uint8_t *ptr = (uint8_t*) &t;
+        for (uint16_t i = 0; i < len; i++) {
+            *ptr++ = EEPROM.read(adr + i);
+        }
+        return true;
+    }
+
+    template <typename T>
+    const bool write_block(uint16_t adr, const T &t)
+    {
+        if (adr + sizeof(T) > _eepromLength) return false;
+        EEPROM.put(adr, t);
+        return true;
+    }
+
+    template <typename T>
+    const bool write_block(uint16_t adr, const T &t, uint16_t len)
+    {
+        if (adr + len > _eepromLength) return false;
+        for (uint16_t i = 0; i < len; i++) {
+            EEPROM.put(adr + i, t[i]);
+        }
+        return true;
+    }
 };
 
 // MFEEPROM.h

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -154,17 +154,6 @@ void setup()
     cmdMessenger.printLfCr();
     ResetBoard();
     initPollIntervals();
-
-    Serial.print("UniqueID: ");
-	for (size_t i = 0; i < UniqueIDsize; i++)
-	{
-		if (UniqueID[i] < 0x10)
-			Serial.print("0");
-		Serial.print(UniqueID[i], HEX);
-		Serial.print(" ");
-	}
-	Serial.println();
-
 }
 
 // ************************************************************

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -9,6 +9,7 @@
 #include "Button.h"
 #include "Encoder.h"
 #include "MFEEPROM.h"
+#include "ArduinoUniqueID.h"
 #if MF_ANALOG_SUPPORT == 1
 #include "Analog.h"
 #endif
@@ -153,6 +154,17 @@ void setup()
     cmdMessenger.printLfCr();
     ResetBoard();
     initPollIntervals();
+
+    Serial.print("UniqueID: ");
+	for (size_t i = 0; i < UniqueIDsize; i++)
+	{
+		if (UniqueID[i] < 0x10)
+			Serial.print("0");
+		Serial.print(UniqueID[i], HEX);
+		Serial.print(" ");
+	}
+	Serial.println();
+
 }
 
 // ************************************************************


### PR DESCRIPTION
@DocMoebiuz and @neilenns found a library with an undocumented feature to read an UniqueID on Atmega2560 and ATmega328. For new boards on first start up this UniqueID is used. In the library is also stated, that it might be possible that
two or more could have the same UniqueID (https://github.com/ricaun/ArduinoUniqueID/blob/master/MCU.md#Disclaimer).
My tests have shown that my megas have different UniqueID's.
But as this can not be excluded, generating a serial number as command from the connector is still available. In this case the random generator is used as before but the starting point are the milliseconds from starting up the board. It is very! unlikely to generate the serial number on exactly the same milliseconds between different boards, so a double serial number should not be generates anymore.

On startup of the board it is checked if a serial number was always generated. This is marked in the EEPROM with "SN" on the first two memory locations. In this case this serial number will still be used. Nothing changes for the user.

If a serial number is not available, it is checked if "ID" was written to the EEPROM. This means it is NOT the first start up and the UniqueID will be used as serial number.

If "SN" and "ID" is not read from the EEPROM, it is a first start up of the board an the UniqueID is used as serial number. This is also marked with writing "ID" to the first two EEPROM locations from the serial number locations.

If the user actively request a new serial number, a serial number according the existing style is generated and marked in the EEPROM with "SN". The starting point for the random generator is NOT anymore the analog input A0, it is the time difference from starting up the board until the command to generate a new serial (simply millis()).

In case a UniqueID is used, the serial number is longer than before. The array size for storing the serial number is calculated accordingly for the max. numbers of characters. The original definition `MEM_LEN_SERIAL` is kept, otherwise the device configuration would start at another position in the EEPROM.

Fixes #229 
