### PR TITLE
Make the 7segs more reliable by resetting before a new display

### DIFF
--- a/src/MF_Segment/MFSegments.cpp
+++ b/src/MF_Segment/MFSegments.cpp
@@ -17,6 +17,9 @@ void MFSegments::display(byte module, char *string, byte points, byte mask, bool
         return;
     byte digit = 8;
     byte pos   = 0;
+    _ledControl.shutdown(module, true);
+    _ledControl.setScanLimit(module, 7);
+
     for (uint8_t i = 0; i < 8; i++) {
         digit--;
         if (((1 << digit) & mask) == 0)
@@ -24,6 +27,8 @@ void MFSegments::display(byte module, char *string, byte points, byte mask, bool
         _ledControl.setChar(module, digit, string[pos], ((1 << digit) & points));
         pos++;
     }
+
+    _ledControl.shutdown(module, false);
 }
 
 void MFSegments::setBrightness(byte module, byte value)


### PR DESCRIPTION
## Description of changes

The 7 segment displays do not always show updates properly.  After time, they become less reliable because they are never reset (shutdown).  I found that this is easily resolved by including a shutdown, reset the scan limit (to 7, the max to ensure uniform brightness) and re-activation on each display call.

According to the datasheet, the MAX7219 chip initialises the scan limit to 1 initially, so this also ensures it is correctly set.
https://www.sparkfun.com/datasheets/Components/General/COM-09622-MAX7219-MAX7221.pdf 

Pull request notes:
Sorry, this is my first pull request to you guys, so I hope this is ok, and happy to discuss.  My email is peter.masters at gmail dot com.  I tested this by running the mobiflight "test" cycle against 4 displays, which corrupt after some minutes (which I could test repeatedly).  When I ran a separate arduino program to test the digits, this never caused the issue.  By working through the logic, I found the difference compared with the LedControl logic you've used, and tried out the difference.  With this fix in place, the 7 segment displays remain reliable indefinitely.
_Describe changes here_
