### PR TITLE
Increase nano max analog count to 8

### DIFF
--- a/_Boards/Atmel/Board_Nano/MFBoards.h
+++ b/_Boards/Atmel/Board_Nano/MFBoards.h
@@ -43,7 +43,7 @@
 #define MAX_STEPPERS        2
 #define MAX_MFSERVOS        2
 #define MAX_MFLCD_I2C       2
-#define MAX_ANALOG_INPUTS   6
+#define MAX_ANALOG_INPUTS   8
 #define MAX_OUTPUT_SHIFTERS 2
 #define MAX_INPUT_SHIFTERS  2
 #define MAX_DIGIN_MUX       3


### PR DESCRIPTION
Fixes #241

Increase the max number of analog pins on the Nano to 8, to account for A6 and A7 also being options.