### PR TITLE
Add custom_ prefix to remove build warning

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
 	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4
 	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
 	ricaun/ArduinoUniqueID @ ^1.3.0
-lib_deps_Atmel =
+custom_lib_deps_Atmel =
 	arduino-libraries/Servo @ 1.1.8
 build_flags =
 	-DMF_REDUCE_FUNCT_LEDCONTROL
@@ -64,7 +64,7 @@ build_src_filter =
 	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}
-	${env.lib_deps_Atmel}
+	${env.custom_lib_deps_Atmel}
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
@@ -82,7 +82,7 @@ build_src_filter =
 	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}
-	${env.lib_deps_Atmel}
+	${env.custom_lib_deps_Atmel}
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
@@ -101,7 +101,7 @@ build_src_filter =
 	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}
-	${env.lib_deps_Atmel}
+	${env.custom_lib_deps_Atmel}
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
@@ -119,7 +119,7 @@ build_src_filter =
 	+<../_Boards/Atmel>
 lib_deps =
 	${env.lib_deps}
-	${env.lib_deps_Atmel}
+	${env.custom_lib_deps_Atmel}
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
@@ -145,5 +145,6 @@ build_src_filter =
 lib_deps =
 	${env.lib_deps}
 monitor_speed = 115200
+monitor_port = COM30
 extra_scripts = 
 	${env.extra_scripts}

--- a/platformio.ini
+++ b/platformio.ini
@@ -145,6 +145,5 @@ build_src_filter =
 lib_deps =
 	${env.lib_deps}
 monitor_speed = 115200
-monitor_port = COM30
 extra_scripts = 
 	${env.extra_scripts}


### PR DESCRIPTION
Fixes #243 

Add a `custom_` prefix to the `lib_deps_Amtel` environment variable to remove the build warning.