### PR TITLE
Remove unused temp variable

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -78,7 +78,7 @@ bool readConfigLength()
 
     while (MFeeprom.read_byte(addreeprom++) != 0x00) {
         configLength++;
-        if (addreeprom > length)                                       // abort if EEPROM size will be exceeded
+        if (addreeprom > length)
         {
             cmdMessenger.sendCmd(kStatus, F("Loading config failed")); // text or "-1" like config upload?
             return false;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -72,14 +72,13 @@ void _activateConfig();
 // reads the EEPROM until NUL terminator and returns the number of characters incl. terminator, starting from given address
 bool readConfigLength()
 {
-    char     temp       = 0;
     uint16_t addreeprom = MEM_OFFSET_CONFIG;
     uint16_t length     = MFeeprom.get_length();
     configLength        = 0;
 
     while (MFeeprom.read_byte(addreeprom++) != 0x00) {
         configLength++;
-        if (addreeprom > length) // abort if EEPROM size will be exceeded
+        if (addreeprom > length)                                       // abort if EEPROM size will be exceeded
         {
             cmdMessenger.sendCmd(kStatus, F("Loading config failed")); // text or "-1" like config upload?
             return false;
@@ -210,8 +209,8 @@ bool readNameFromEEPROM(uint16_t *addreeprom, char *buffer, uint16_t *addrbuffer
         if (*addrbuffer >= MEMLEN_NAMES_BUFFER) {                      // nameBuffer will be exceeded
             return false;                                              // abort copying from EEPROM to nameBuffer
         }
-    } while (temp != ':');            // reads until limiter ':' and locates the next free buffer position
-    buffer[(*addrbuffer) - 1] = 0x00; // replace ':' by NULL, terminates the string
+    } while (temp != ':');                                             // reads until limiter ':' and locates the next free buffer position
+    buffer[(*addrbuffer) - 1] = 0x00;                                  // replace ':' by NULL, terminates the string
     return true;
 }
 
@@ -224,13 +223,13 @@ bool readEndCommandFromEEPROM(uint16_t *addreeprom)
         temp = MFeeprom.read_byte((*addreeprom)++);
         if (*addreeprom > length) // abort if EEPROM size will be exceeded
             return false;
-    } while (temp != ':'); // reads until limiter ':'
+    } while (temp != ':');        // reads until limiter ':'
     return true;
 }
 
 void readConfig()
 {
-    if (configLength == 0) // do nothing if no config is available
+    if (configLength == 0)                                   // do nothing if no config is available
         return;
     uint16_t addreeprom   = MEM_OFFSET_CONFIG;               // define first memory location where config is saved in EEPROM
     uint16_t addrbuffer   = 0;                               // and start with first memory location from nameBuffer
@@ -239,7 +238,7 @@ void readConfig()
     bool     copy_success = true;                            // will be set to false if copying input names to nameBuffer exceeds array dimensions
                                                              // not required anymore when pins instead of names are transferred to the UI
 
-    if (command == 0) // just to be sure, configLength should also be 0
+    if (command == 0)                                        // just to be sure, configLength should also be 0
         return;
 
     do // go through the EEPROM until it is NULL terminated
@@ -252,18 +251,18 @@ void readConfig()
             break;
 
         case kTypeOutput:
-            params[0] = readUintFromEEPROM(&addreeprom); // Pin number
+            params[0] = readUintFromEEPROM(&addreeprom);          // Pin number
             Output::Add(params[0]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
 
 #if MF_SEGMENT_SUPPORT == 1
         case kTypeLedSegment:
-            params[0] = readUintFromEEPROM(&addreeprom); // Pin Data number
-            params[1] = readUintFromEEPROM(&addreeprom); // Pin CS number
-            params[2] = readUintFromEEPROM(&addreeprom); // Pin CLK number
-            params[3] = readUintFromEEPROM(&addreeprom); // brightness
-            params[4] = readUintFromEEPROM(&addreeprom); // number of modules
+            params[0] = readUintFromEEPROM(&addreeprom);          // Pin Data number
+            params[1] = readUintFromEEPROM(&addreeprom);          // Pin CS number
+            params[2] = readUintFromEEPROM(&addreeprom);          // Pin CLK number
+            params[3] = readUintFromEEPROM(&addreeprom);          // brightness
+            params[4] = readUintFromEEPROM(&addreeprom);          // number of modules
             LedSegment::Add(params[0], params[1], params[2], params[4], params[3]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
@@ -272,21 +271,21 @@ void readConfig()
 #if MF_STEPPER_SUPPORT == 1
         case kTypeStepperDeprecated1:
             // this is for backwards compatibility
-            params[0] = readUintFromEEPROM(&addreeprom); // Pin1 number
-            params[1] = readUintFromEEPROM(&addreeprom); // Pin2 number
-            params[2] = readUintFromEEPROM(&addreeprom); // Pin3 number
-            params[3] = readUintFromEEPROM(&addreeprom); // Pin4 number
-            params[4] = readUintFromEEPROM(&addreeprom); // Button number
+            params[0] = readUintFromEEPROM(&addreeprom);          // Pin1 number
+            params[1] = readUintFromEEPROM(&addreeprom);          // Pin2 number
+            params[2] = readUintFromEEPROM(&addreeprom);          // Pin3 number
+            params[3] = readUintFromEEPROM(&addreeprom);          // Pin4 number
+            params[4] = readUintFromEEPROM(&addreeprom);          // Button number
             Stepper::Add(params[0], params[1], params[2], params[3], 0);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
 
         case kTypeStepperDeprecated2:
-            params[0] = readUintFromEEPROM(&addreeprom); // Pin1 number
-            params[1] = readUintFromEEPROM(&addreeprom); // Pin2 number
-            params[2] = readUintFromEEPROM(&addreeprom); // Pin3 number
-            params[3] = readUintFromEEPROM(&addreeprom); // Pin4 number
-            params[4] = readUintFromEEPROM(&addreeprom); // Button number
+            params[0] = readUintFromEEPROM(&addreeprom);          // Pin1 number
+            params[1] = readUintFromEEPROM(&addreeprom);          // Pin2 number
+            params[2] = readUintFromEEPROM(&addreeprom);          // Pin3 number
+            params[3] = readUintFromEEPROM(&addreeprom);          // Pin4 number
+            params[4] = readUintFromEEPROM(&addreeprom);          // Button number
             Stepper::Add(params[0], params[1], params[2], params[3], params[4]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
@@ -309,7 +308,7 @@ void readConfig()
 
 #if MF_SERVO_SUPPORT == 1
         case kTypeServo:
-            params[0] = readUintFromEEPROM(&addreeprom); // Pin number
+            params[0] = readUintFromEEPROM(&addreeprom);          // Pin number
             Servos::Add(params[0]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
@@ -334,9 +333,9 @@ void readConfig()
 
 #if MF_LCD_SUPPORT == 1
         case kTypeLcdDisplayI2C:
-            params[0] = readUintFromEEPROM(&addreeprom); // address
-            params[1] = readUintFromEEPROM(&addreeprom); // columns
-            params[2] = readUintFromEEPROM(&addreeprom); // lines
+            params[0] = readUintFromEEPROM(&addreeprom);          // address
+            params[1] = readUintFromEEPROM(&addreeprom);          // columns
+            params[2] = readUintFromEEPROM(&addreeprom);          // lines
             LCDDisplay::Add(params[0], params[1], params[2]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
@@ -354,10 +353,10 @@ void readConfig()
 
 #if MF_OUTPUT_SHIFTER_SUPPORT == 1
         case kTypeOutputShifter:
-            params[0] = readUintFromEEPROM(&addreeprom); // latch Pin
-            params[1] = readUintFromEEPROM(&addreeprom); // clock Pin
-            params[2] = readUintFromEEPROM(&addreeprom); // data Pin
-            params[3] = readUintFromEEPROM(&addreeprom); // number of daisy chained modules
+            params[0] = readUintFromEEPROM(&addreeprom);          // latch Pin
+            params[1] = readUintFromEEPROM(&addreeprom);          // clock Pin
+            params[2] = readUintFromEEPROM(&addreeprom);          // data Pin
+            params[3] = readUintFromEEPROM(&addreeprom);          // number of daisy chained modules
             OutputShifter::Add(params[0], params[1], params[2], params[3]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
@@ -365,10 +364,10 @@ void readConfig()
 
 #if MF_INPUT_SHIFTER_SUPPORT == 1
         case kTypeInputShifter:
-            params[0] = readUintFromEEPROM(&addreeprom); // latch Pin
-            params[1] = readUintFromEEPROM(&addreeprom); // clock Pin
-            params[2] = readUintFromEEPROM(&addreeprom); // data Pin
-            params[3] = readUintFromEEPROM(&addreeprom); // number of daisy chained modules
+            params[0] = readUintFromEEPROM(&addreeprom);                             // latch Pin
+            params[1] = readUintFromEEPROM(&addreeprom);                             // clock Pin
+            params[2] = readUintFromEEPROM(&addreeprom);                             // data Pin
+            params[3] = readUintFromEEPROM(&addreeprom);                             // number of daisy chained modules
             InputShifter::Add(params[0], params[1], params[2], params[3], &nameBuffer[addrbuffer]);
             copy_success = readNameFromEEPROM(&addreeprom, nameBuffer, &addrbuffer); // copy the NULL terminated name to to nameBuffer and set to next free memory location
                                                                                      //    copy_success = readEndCommandFromEEPROM(&addreeprom);       // once the nameBuffer is not required anymore uncomment this line and delete the line before


### PR DESCRIPTION
Fixes #245 

Removes the unused `temp` variable. The variable was introduced [here](https://github.com/MobiFlight/MobiFlight-FirmwareSource/commit/e00bc34c23328801ca5866886c33a173ba641eb5).