### PR TITLE
Increase Analog Input on Nano/ProMicro

### DIFF
--- a/_Boards/Atmel/Board_Nano/MFBoards.h
+++ b/_Boards/Atmel/Board_Nano/MFBoards.h
@@ -43,7 +43,7 @@
 #define MAX_STEPPERS        2
 #define MAX_MFSERVOS        2
 #define MAX_MFLCD_I2C       2
-#define MAX_ANALOG_INPUTS   6
+#define MAX_ANALOG_INPUTS   8
 #define MAX_OUTPUT_SHIFTERS 2
 #define MAX_INPUT_SHIFTERS  2
 #define MAX_DIGIN_MUX       3

--- a/_Boards/Atmel/Board_ProMicro/MFBoards.h
+++ b/_Boards/Atmel/Board_ProMicro/MFBoards.h
@@ -43,7 +43,7 @@
 #define MAX_STEPPERS        3
 #define MAX_MFSERVOS        3
 #define MAX_MFLCD_I2C       2
-#define MAX_ANALOG_INPUTS   5
+#define MAX_ANALOG_INPUTS   9
 #define MAX_OUTPUT_SHIFTERS 2
 #define MAX_INPUT_SHIFTERS  2
 #define MAX_DIGIN_MUX       3


### PR DESCRIPTION
This PR will increase the Analog Input on the Nano to 8 and on the ProMicro to 9

For the Nano with the limited device buffer additional devices could be limited, depending on the memory consumption for other devices.
Implementing PR #219  will increase the max. number of devices which can be configured.

Fixes #247 
