### PR TITLE
Wrap defines

### DIFF
--- a/_Boards/Atmel/Board_Mega/MFBoards.h
+++ b/_Boards/Atmel/Board_Mega/MFBoards.h
@@ -70,14 +70,27 @@
 #define MAX_DIGIN_MUX       4
 #endif
 
+#ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Mega"
+#endif
+#ifndef MOBIFLIGHT_SERIAL
 #define MOBIFLIGHT_SERIAL   "1234567890"
+#endif
+#ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Mega"
+#endif
+#ifndef EEPROM_SIZE
 #define EEPROM_SIZE         4096 // EEPROMSizeMega
+#endif
+#ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG       1496 // max. size for config which wil be stored in EEPROM
+#endif
+#ifndef MEMLEN_NAMES_BUFFER
 #define MEMLEN_NAMES_BUFFER 1000 // max. size for configBuffer, contains only names from inputs
+#endif
+#ifndef MF_MAX_DEVICEMEM
 #define MF_MAX_DEVICEMEM    1500 // max. memory size for devices
-
+#endif
 
 #endif
 

--- a/_Boards/Atmel/Board_Mega/MFBoards.h
+++ b/_Boards/Atmel/Board_Mega/MFBoards.h
@@ -36,17 +36,39 @@
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
 
+#ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         40
+#endif
+#ifndef MAX_BUTTONS
 #define MAX_BUTTONS         68
+#endif
+#ifndef MAX_LEDSEGMENTS
 #define MAX_LEDSEGMENTS     4
+#endif
+#ifndef MAX_ENCODERS
 #define MAX_ENCODERS        20
+#endif
+#ifndef MAX_STEPPERS
 #define MAX_STEPPERS        10
+#endif
+#ifndef MAX_MFSERVOS
 #define MAX_MFSERVOS        10
+#endif
+#ifndef MAX_MFLCD_I2C
 #define MAX_MFLCD_I2C       2
+#endif
+#ifndef MAX_ANALOG_INPUTS
 #define MAX_ANALOG_INPUTS   16
+#endif
+#ifndef MAX_OUTPUT_SHIFTERS
 #define MAX_OUTPUT_SHIFTERS 4
+#endif
+#ifndef MAX_INPUT_SHIFTERS
 #define MAX_INPUT_SHIFTERS  4
+#endif
+#ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       4
+#endif
 
 #define MOBIFLIGHT_TYPE     "MobiFlight Mega"
 #define MOBIFLIGHT_SERIAL   "1234567890"

--- a/_Boards/Atmel/Board_Nano/MFBoards.h
+++ b/_Boards/Atmel/Board_Nano/MFBoards.h
@@ -74,14 +74,27 @@
 #define STEPPER_SPEED 400 // 300 already worked, 467, too?
 #define STEPPER_ACCEL 800
 
+#ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Nano"
+#endif
+#ifndef MOBIFLIGHT_SERIAL
 #define MOBIFLIGHT_SERIAL   "0987654321"
+#endif
+#ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Nano"
+#endif
+#ifndef EEPROM_SIZE
 #define EEPROM_SIZE         1024 // EEPROMSizeUno
+#endif
+#ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG       286  // max. size for config which wil be stored in EEPROM
+#endif
+#ifndef MEMLEN_NAMES_BUFFER
 #define MEMLEN_NAMES_BUFFER 220  // max. size for configBuffer, contains only names from inputs
+#endif
+#ifndef MF_MAX_DEVICEMEM
 #define MF_MAX_DEVICEMEM    300  // max. memory size for devices
-
+#endif
 
 #endif
 

--- a/_Boards/Atmel/Board_Nano/MFBoards.h
+++ b/_Boards/Atmel/Board_Nano/MFBoards.h
@@ -36,17 +36,39 @@
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
 
+#ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18
+#endif
+#ifndef MAX_BUTTONS
 #define MAX_BUTTONS         18
+#endif
+#ifndef MAX_LEDSEGMENTS
 #define MAX_LEDSEGMENTS     1
+#endif
+#ifndef MAX_ENCODERS
 #define MAX_ENCODERS        9
+#endif
+#ifndef MAX_STEPPERS
 #define MAX_STEPPERS        2
+#endif
+#ifndef MAX_MFSERVOS
 #define MAX_MFSERVOS        2
+#endif
+#ifndef MAX_MFLCD_I2C
 #define MAX_MFLCD_I2C       2
+#endif
+#ifndef MAX_ANALOG_INPUTS
 #define MAX_ANALOG_INPUTS   8
+#endif
+#ifndef MAX_OUTPUT_SHIFTERS
 #define MAX_OUTPUT_SHIFTERS 2
+#endif
+#ifndef MAX_INPUT_SHIFTERS
 #define MAX_INPUT_SHIFTERS  2
+#endif
+#ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       3
+#endif
 
 #define STEPS         64
 #define STEPPER_SPEED 400 // 300 already worked, 467, too?

--- a/_Boards/Atmel/Board_ProMicro/MFBoards.h
+++ b/_Boards/Atmel/Board_ProMicro/MFBoards.h
@@ -36,17 +36,39 @@
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
 
+#ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18
+#endif
+#ifndef MAX_BUTTONS
 #define MAX_BUTTONS         18
+#endif
+#ifndef MAX_LEDSEGMENTS
 #define MAX_LEDSEGMENTS     1
+#endif
+#ifndef MAX_ENCODERS
 #define MAX_ENCODERS        9
+#endif
+#ifndef MAX_STEPPERS
 #define MAX_STEPPERS        3
+#endif
+#ifndef MAX_MFSERVOS
 #define MAX_MFSERVOS        3
+#endif
+#ifndef MAX_MFLCD_I2C
 #define MAX_MFLCD_I2C       2
+#endif
+#ifndef MAX_ANALOG_INPUTS
 #define MAX_ANALOG_INPUTS   9
+#endif
+#ifndef MAX_OUTPUT_SHIFTERS
 #define MAX_OUTPUT_SHIFTERS 2
+#endif
+#ifndef MAX_INPUT_SHIFTERS
 #define MAX_INPUT_SHIFTERS  2
+#endif
+#ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       3
+#endif
 
 #define MOBIFLIGHT_TYPE     "MobiFlight Micro"
 #define MOBIFLIGHT_SERIAL   "0987654321"

--- a/_Boards/Atmel/Board_ProMicro/MFBoards.h
+++ b/_Boards/Atmel/Board_ProMicro/MFBoards.h
@@ -70,14 +70,27 @@
 #define MAX_DIGIN_MUX       3
 #endif
 
+#ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Micro"
+#endif
+#ifndef MOBIFLIGHT_SERIAL
 #define MOBIFLIGHT_SERIAL   "0987654321"
+#endif
+#ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Micro"
+#endif
+#ifndef EEPROM_SIZE
 #define EEPROM_SIZE         1024 // EEPROMSizeMicro
+#endif
+#ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG       440  // max. size for config which wil be stored in EEPROM
+#endif
+#ifndef MEMLEN_NAMES_BUFFER
 #define MEMLEN_NAMES_BUFFER 350  // max. size for configBuffer, contains only names from inputs
+#endif
+#ifndef MF_MAX_DEVICEMEM
 #define MF_MAX_DEVICEMEM    400  // max. memory size for devices
-
+#endif
 
 #endif
 

--- a/_Boards/Atmel/Board_Uno/MFBoards.h
+++ b/_Boards/Atmel/Board_Uno/MFBoards.h
@@ -36,17 +36,39 @@
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
 
+#ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18
+#endif
+#ifndef MAX_BUTTONS
 #define MAX_BUTTONS         18
+#endif
+#ifndef MAX_LEDSEGMENTS
 #define MAX_LEDSEGMENTS     1
+#endif
+#ifndef MAX_ENCODERS
 #define MAX_ENCODERS        9
+#endif
+#ifndef MAX_STEPPERS
 #define MAX_STEPPERS        2
+#endif
+#ifndef MAX_MFSERVOS
 #define MAX_MFSERVOS        2
+#endif
+#ifndef MAX_MFLCD_I2C
 #define MAX_MFLCD_I2C       2
+#endif
+#ifndef MAX_ANALOG_INPUTS
 #define MAX_ANALOG_INPUTS   6
+#endif
+#ifndef MAX_OUTPUT_SHIFTERS
 #define MAX_OUTPUT_SHIFTERS 2
+#endif
+#ifndef MAX_INPUT_SHIFTERS
 #define MAX_INPUT_SHIFTERS  2
+#endif
+#ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       3
+#endif
 
 #define MOBIFLIGHT_TYPE     "MobiFlight Uno"
 #define MOBIFLIGHT_SERIAL   "0987654321"

--- a/_Boards/Atmel/Board_Uno/MFBoards.h
+++ b/_Boards/Atmel/Board_Uno/MFBoards.h
@@ -70,14 +70,27 @@
 #define MAX_DIGIN_MUX       3
 #endif
 
+#ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Uno"
+#endif
+#ifndef MOBIFLIGHT_SERIAL
 #define MOBIFLIGHT_SERIAL   "0987654321"
+#endif
+#ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Uno"
+#endif
+#ifndef EEPROM_SIZE
 #define EEPROM_SIZE         1024 // EEPROMSizeUno
+#endif
+#ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG       286  // max. size for config which wil be stored in EEPROM
+#endif
+#ifndef MEMLEN_NAMES_BUFFER
 #define MEMLEN_NAMES_BUFFER 220  // max. size for configBuffer, contains only names from inputs
+#endif
+#ifndef MF_MAX_DEVICEMEM
 #define MF_MAX_DEVICEMEM    300  // max. memory size for devices
-
+#endif
 
 #endif
 

--- a/_Boards/RaspberryPi/Pico/MFBoards.h
+++ b/_Boards/RaspberryPi/Pico/MFBoards.h
@@ -68,12 +68,26 @@
 #define STEPPER_SPEED       400     // 300 already worked, 467, too?
 #define STEPPER_ACCEL       800
 
+#ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE         "MobiFlight RaspiPico"
+#endif
+#ifndef MOBIFLIGHT_SERIAL
 #define MOBIFLIGHT_SERIAL       "0987654321"
+#endif
+#ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME         "MobiFlight RaspiPico"
+#endif
+#ifndef EEPROM_SIZE
 #define EEPROM_SIZE             4096    // EEPROMSizeRaspberryPico
+#endif
+#ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG           1496    // MUST be less than EEPROM_SIZE!! MEM_OFFSET_CONFIG + MEM_LEN_CONFIG <= EEPROM_SIZE, see: eeprom_write_block (MEM_OFFSET_CONFIG, configBuffer, MEM_LEN_CONFIG);
+#endif
+#ifndef MEMLEN_NAMES_BUFFER
 #define MEMLEN_NAMES_BUFFER     1000    // max. size for configBuffer, contains only names from inputs
+#endif
+#ifndef MF_MAX_DEVICEMEM
 #define MF_MAX_DEVICEMEM        2000    // max. memory size for devices
+#endif
 
 #endif

--- a/_Boards/RaspberryPi/Pico/MFBoards.h
+++ b/_Boards/RaspberryPi/Pico/MFBoards.h
@@ -30,17 +30,39 @@
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
 
+#ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         26
+#endif
+#ifndef MAX_BUTTONS
 #define MAX_BUTTONS         26
+#endif
+#ifndef MAX_LEDSEGMENTS
 #define MAX_LEDSEGMENTS     4
+#endif
+#ifndef MAX_ENCODERS
 #define MAX_ENCODERS        8
+#endif
+#ifndef MAX_STEPPERS
 #define MAX_STEPPERS        6
+#endif
+#ifndef MAX_MFSERVOS
 #define MAX_MFSERVOS        8
+#endif
+#ifndef MAX_MFLCD_I2C
 #define MAX_MFLCD_I2C       2
+#endif
+#ifndef MAX_ANALOG_INPUTS
 #define MAX_ANALOG_INPUTS   3
+#endif
+#ifndef MAX_OUTPUT_SHIFTERS
 #define MAX_OUTPUT_SHIFTERS 4
+#endif
+#ifndef MAX_INPUT_SHIFTERS
 #define MAX_INPUT_SHIFTERS  4
+#endif
+#ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       4
+#endif
 
 #define STEPS               64
 #define STEPPER_SPEED       400     // 300 already worked, 467, too?


### PR DESCRIPTION
Fixes #249 

## Description of changes

Add `#ifndef` around all of the defines in the MFBoard.h files. Doesn't result in any change in functionality, just enables setting them via environment variables in the future.