### PR TITLE
Wrong define for debug message to connector

### DIFF
--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -40,7 +40,7 @@ namespace DigInMux
         MFDigInMux::attachHandler(handlerOnDigInMux);
         digInMuxRegistered++;
 
-#ifdef DEBUG2MSG
+#ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kDebug, F("Added digital input MUX"));
 #endif
     }

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -28,6 +28,10 @@ std::size_t    *allocateMemory(uint8_t size)
     }
 #ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmdStart(kDebug);
+    cmdMessenger.sendCmdArg(F("Bytes added"));
+    cmdMessenger.sendCmdArg(size);
+    cmdMessenger.sendCmdEnd();
+    cmdMessenger.sendCmdStart(kDebug);
     cmdMessenger.sendCmdArg(F("BufferUsage"));
     cmdMessenger.sendCmdArg(nextPointer);
     cmdMessenger.sendCmdEnd();


### PR DESCRIPTION
## Description of changes

Define `DEBUG2MSG` replaced by `DEBUG2CMDMESSENGER `to get this info during debuging to the connector.

Added an additionally print to the connector to get the size of devices which gets registered in the device buffer.

Fixes #254 