### PR TITLE
Fixed exceeding digInMux array

### DIFF
--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -48,7 +48,7 @@ namespace DigInMux
     void Clear()
     {
         for (uint8_t i = 0; i < digInMuxRegistered; i++) {
-            digInMux[digInMuxRegistered]->detach();
+            digInMux[i]->detach();
         }
         digInMuxRegistered = 0;
 #ifdef DEBUG2CMDMESSENGER


### PR DESCRIPTION
## Description of changes

In the `for` loop the array `digInMux[]` gets not exceeded anymore as `i` is used instead of`digInMuxRegistered` for the array index.

Fixes #255 