### PR TITLE
Custom devices new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade platformio
 
-      - name: Checkout component library
+      - name: Checkout custom devices
         uses: actions/checkout@v3
         with:
           repository: elral/MobiFlight-CustomDevices

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout custom devices
         uses: actions/checkout@v3
         with:
-          repository: elral/MobiFlight-CustomDevices
+          repository: MobiFlight/MobiFlight-CustomDevices
           path: CustomDevices
 
       - name: Run PlatformIO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout component library
         uses: actions/checkout@v3
         with:
-          repository: MobiFlight/MobiFlight-CustomDevices
+          repository: elral/MobiFlight-CustomDevices
           path: CustomDevices
 
       - name: Run PlatformIO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade platformio
 
+      - name: Checkout component library
+        uses: actions/checkout@v3
+        with:
+          repository: MobiFlight/MobiFlight-CustomDevices
+          path: CustomDevices
+
       - name: Run PlatformIO
         env:
           VERSION: "0.0.${{ github.event.number }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,5 @@ jobs:
         with:
           name: firmware
           path: |
-            .pio/build/**/mobiflight*.hex
-            .pio/build/**/mobiflight*.uf2
+            .pio/build/**/*.hex
+            .pio/build/**/*.uf2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade platformio
 
-      - name: Checkout component library
+      - name: Checkout custom devices
         uses: actions/checkout@v3
         with:
           repository: elral/MobiFlight-CustomDevices

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout custom devices
         uses: actions/checkout@v3
         with:
-          repository: elral/MobiFlight-CustomDevices
+          repository: MobiFlight/MobiFlight-CustomDevices
           path: CustomDevices
 
       - name: Extract build version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           name: firmware
           path: |
-            .pio/build/**/mobiflight*.hex
-            .pio/build/**/mobiflight*.uf2
+            .pio/build/**/*.hex
+            .pio/build/**/*.uf2
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -61,5 +61,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            .pio/build/**/mobiflight*.hex
-            .pio/build/**/mobiflight*.uf2
+            .pio/build/**/*.hex
+            .pio/build/**/*.uf2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade platformio
 
+      - name: Checkout component library
+        uses: actions/checkout@v3
+        with:
+          repository: MobiFlight/MobiFlight-CustomDevices
+          path: CustomDevices
+
       - name: Extract build version
         id: get_version
         uses: battila7/get-version-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout component library
         uses: actions/checkout@v3
         with:
-          repository: MobiFlight/MobiFlight-CustomDevices
+          repository: elral/MobiFlight-CustomDevices
           path: CustomDevices
 
       - name: Extract build version

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/launch.json
 .vscode/ipch
 .vscode/arduino.json
+.CustomDevices

--- a/_Boards/Atmel/Board_Mega/MFBoards.h
+++ b/_Boards/Atmel/Board_Mega/MFBoards.h
@@ -35,6 +35,9 @@
 #define MF_MUX_SUPPORT       1
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
+#ifndef MF_CUSTOMDEVICE_SUPPORT
+#define MF_CUSTOMDEVICE_SUPPORT 1
+#endif
 
 #ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         40
@@ -68,6 +71,9 @@
 #endif
 #ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       4
+#endif
+#ifndef MAX_CUSTOM_DEVICES
+#define MAX_CUSTOM_DEVICES  5
 #endif
 
 #ifndef MOBIFLIGHT_TYPE

--- a/_Boards/Atmel/Board_Nano/MFBoards.h
+++ b/_Boards/Atmel/Board_Nano/MFBoards.h
@@ -35,6 +35,9 @@
 #define MF_MUX_SUPPORT       1
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
+#ifndef MF_CUSTOMDEVICE_SUPPORT
+#define MF_CUSTOMDEVICE_SUPPORT 2
+#endif
 
 #ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18
@@ -69,10 +72,9 @@
 #ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       3
 #endif
-
-#define STEPS         64
-#define STEPPER_SPEED 400 // 300 already worked, 467, too?
-#define STEPPER_ACCEL 800
+#ifndef MAX_CUSTOM_DEVICES
+#define MAX_CUSTOM_DEVICES  2
+#endif
 
 #ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Nano"

--- a/_Boards/Atmel/Board_ProMicro/MFBoards.h
+++ b/_Boards/Atmel/Board_ProMicro/MFBoards.h
@@ -35,6 +35,9 @@
 #define MF_MUX_SUPPORT       1
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
+#ifndef MF_CUSTOMDEVICE_SUPPORT
+#define MF_CUSTOMDEVICE_SUPPORT 2
+#endif
 
 #ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18
@@ -68,6 +71,9 @@
 #endif
 #ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       3
+#endif
+#ifndef MAX_CUSTOM_DEVICES
+#define MAX_CUSTOM_DEVICES  2
 #endif
 
 #ifndef MOBIFLIGHT_TYPE

--- a/_Boards/Atmel/Board_Uno/MFBoards.h
+++ b/_Boards/Atmel/Board_Uno/MFBoards.h
@@ -35,6 +35,9 @@
 #define MF_MUX_SUPPORT       1
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
+#ifndef MF_CUSTOMDEVICE_SUPPORT
+#define MF_CUSTOMDEVICE_SUPPORT 2
+#endif
 
 #ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18
@@ -68,6 +71,9 @@
 #endif
 #ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       3
+#endif
+#ifndef MAX_CUSTOM_DEVICES
+#define MAX_CUSTOM_DEVICES  2
 #endif
 
 #ifndef MOBIFLIGHT_TYPE

--- a/_Boards/RaspberryPi/Pico/MFBoards.h
+++ b/_Boards/RaspberryPi/Pico/MFBoards.h
@@ -63,10 +63,9 @@
 #ifndef MAX_DIGIN_MUX
 #define MAX_DIGIN_MUX       4
 #endif
-
-#define STEPS               64
-#define STEPPER_SPEED       400     // 300 already worked, 467, too?
-#define STEPPER_ACCEL       800
+#ifndef MAX_CUSTOM_DEVICES
+#define MAX_CUSTOM_DEVICES  5
+#endif
 
 #ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE         "MobiFlight RaspiPico"

--- a/get_CustomDevices.py
+++ b/get_CustomDevices.py
@@ -1,0 +1,12 @@
+import os
+
+Import("env")
+
+CUSTOMDEVICES_DIR = env.subst("$PROJECT_DIR/CustomDevices")
+
+if not os.path.exists(CUSTOMDEVICES_DIR):
+    print ("Cloning Mobiflight-CustomDevices repo ... ")
+    env.Execute("git clone --depth 100 https://github.com/elral/MobiFlight-CustomDevices $PROJECT_DIR/CustomDevices")
+else:
+    print ("Checking for Mobiflight-CustomDevices repo updates ... ")
+    env.Execute("git --work-tree=$PROJECT_DIR\CustomDevices --git-dir=$PROJECT_DIR\CustomDevices\.git pull origin main --depth 100")

--- a/get_CustomDevices.py
+++ b/get_CustomDevices.py
@@ -6,7 +6,7 @@ CUSTOMDEVICES_DIR = env.subst("$PROJECT_DIR/CustomDevices")
 
 if not os.path.exists(CUSTOMDEVICES_DIR):
     print ("Cloning Mobiflight-CustomDevices repo ... ")
-    env.Execute("git clone --depth 100 https://github.com/elral/MobiFlight-CustomDevices $PROJECT_DIR/CustomDevices")
+    env.Execute("git clone --depth 100 https://github.com/MobiFlight/MobiFlight-CustomDevices $PROJECT_DIR/CustomDevices")
 else:
     print ("Checking for Mobiflight-CustomDevices repo updates ... ")
     env.Execute("git --work-tree=$PROJECT_DIR/CustomDevices --git-dir=$PROJECT_DIR/CustomDevices/.git pull origin main --depth 100")

--- a/get_CustomDevices.py
+++ b/get_CustomDevices.py
@@ -9,4 +9,4 @@ if not os.path.exists(CUSTOMDEVICES_DIR):
     env.Execute("git clone --depth 100 https://github.com/elral/MobiFlight-CustomDevices $PROJECT_DIR/CustomDevices")
 else:
     print ("Checking for Mobiflight-CustomDevices repo updates ... ")
-    env.Execute("git --work-tree=$PROJECT_DIR\CustomDevices --git-dir=$PROJECT_DIR\CustomDevices\.git pull origin main --depth 100")
+    env.Execute("git --work-tree=$PROJECT_DIR/CustomDevices --git-dir=$PROJECT_DIR/CustomDevices/.git pull origin main --depth 100")

--- a/get_version.py
+++ b/get_version.py
@@ -23,4 +23,4 @@ env.Append(CPPDEFINES=[
 ])
 
 # Set the output filename to the name of the board and the version
-env.Replace(PROGNAME=f'mobiflight_{env["PIOENV"]}_{firmware_version.replace(".", "_")}')
+env.Replace(PROGNAME=f'{env["PIOENV"]}_{firmware_version.replace(".", "_")}')

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,6 @@
 [platformio]
 ; include custom environments to be build
 extra_configs =
-	./CustomDevices/_template/MyCustomDevice_platformio.ini
 	./CustomDevices/KAV_Simulation/EFIS_FCU/EFIS_FCU_platformio.ini
 	./CustomDevices/Mobiflight/GNC255/GNC255_platformio.ini
 	./CustomDevices/Mobiflight/TM1637/TM1637_platformio.ini

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,15 @@
 ; development use VSCode to change the target to a non-default
 ; by clicking on the target name in the bottom status bar.
 [platformio]
+; include custom environments to be build
+extra_configs =
+	./CustomDevices/_template/MyCustomDevice_platformio.ini
+	./CustomDevices/KAV_Simulation/EFIS_FCU/EFIS_FCU_platformio.ini
+	./CustomDevices/Mobiflight/GNC255/GNC255_platformio.ini
+	./CustomDevices/Mobiflight/TM1637/TM1637_platformio.ini
+	./CustomDevices/Mobiflight/GenericI2C/GenericI2C_platformio.ini
+	./CustomDevices/_all_CustomDevices/all_devices_platformio.ini
+	
 
 ; Common build settings across all devices
 [env]
@@ -48,20 +57,23 @@ build_flags =
 	-I./src/MF_Modules
 build_src_filter =
 	+<*>
+	-<./MF_CustomDevice>
 extra_scripts =
 	pre:get_version.py
+	pre:get_CustomDevices.py
 
 ; Build settings for the Arduino Mega
-[env:mega]
+[env:mobiflight_mega]
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
 build_flags = 
 	${env.build_flags}
+	-DMF_CUSTOMDEVICE_SUPPORT=0
+	'-DMOBIFLIGHT_TYPE="MobiFlight Mega"'
 	-I./_Boards/Atmel/Board_Mega
 build_src_filter = 
 	${env.build_src_filter}
-	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}
 	${env.custom_lib_deps_Atmel}
@@ -70,16 +82,17 @@ extra_scripts =
 	${env.extra_scripts}
 
 ; Build settings for the Arduino Pro Micro
-[env:micro]
+[env:mobiflight_micro]
 platform = atmelavr
 board = sparkfun_promicro16
 framework = arduino
 build_flags = 
 	${env.build_flags}
+	-DMF_CUSTOMDEVICE_SUPPORT=0
+	'-DMOBIFLIGHT_TYPE="MobiFlight Micro"'
 	-I./_Boards/Atmel/Board_ProMicro
 build_src_filter = 
 	${env.build_src_filter}
-	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}
 	${env.custom_lib_deps_Atmel}
@@ -89,16 +102,17 @@ extra_scripts =
 
 
 ; Build settings for the Arduino Uno
-[env:uno]
+[env:mobiflight_uno]
 platform = atmelavr
 board = uno
 framework = arduino
 build_flags = 
 	${env.build_flags}
+	-DMF_CUSTOMDEVICE_SUPPORT=0
+	'-DMOBIFLIGHT_TYPE="MobiFlight Uno"'
 	-I./_Boards/Atmel/Board_Uno
 build_src_filter = 
 	${env.build_src_filter}
-	+<../_Boards/Atmel>
 lib_deps = 
 	${env.lib_deps}
 	${env.custom_lib_deps_Atmel}
@@ -107,16 +121,17 @@ extra_scripts =
 	${env.extra_scripts}
 
 ; Build settings for the Arduino Nano
-[env:nano]
+[env:mobiflight_nano]
 platform = atmelavr
 board = nanoatmega328
 framework = arduino
 build_flags = 
 	${env.build_flags}
+	-DMF_CUSTOMDEVICE_SUPPORT=0
+	'-DMOBIFLIGHT_TYPE="MobiFlight Nano"'
 	-I./_Boards/Atmel/Board_Nano
 build_src_filter = 
 	${env.build_src_filter}
-	+<../_Boards/Atmel>
 lib_deps =
 	${env.lib_deps}
 	${env.custom_lib_deps_Atmel}
@@ -125,23 +140,22 @@ extra_scripts =
 	${env.extra_scripts}
 
 ; Build settings for the Raspberry Pico original
-[env:raspberrypico]
+[env:mobiflight_raspberrypico]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = pico
 framework = arduino
-board_build.core = earlephilhower			; select new core
-board_build.filesystem_size = 0M			; configure filesystem size. Default 0 Mbyte.
+board_build.core = earlephilhower						; select new core
+board_build.filesystem_size = 0M						; configure filesystem size. Default 0 Mbyte.
 lib_ldf_mode = chain+
-upload_protocol = mbed						; for debugging upoading can be changed to picoprobe
-;debug_tool = picoprobe						; and uncomment this for debugging w/ picoprobe
+upload_protocol = mbed									; for debugging upoading can be changed to picoprobe
+;debug_tool = picoprobe									; and uncomment this for debugging w/ picoprobe
 build_flags =
 	${env.build_flags}
-	-DUSE_INTERRUPT
+	-DMF_CUSTOMDEVICE_SUPPORT=0
+	'-DMOBIFLIGHT_TYPE="MobiFlight RaspiPico"'
 	-I./_Boards/RaspberryPi/Pico
-	-fpermissive
 build_src_filter =
 	${env.build_src_filter}
-	+<../_Boards/RaspberryPi>
 lib_deps =
 	${env.lib_deps}
 monitor_speed = 115200

--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -33,6 +33,9 @@
 #if MF_DIGIN_MUX_SUPPORT == 1
 #include "DigInMux.h"
 #endif
+#if MF_CUSTOMDEVICE_SUPPORT == 1
+#include "CustomDevice.h"
+#endif
 
 CmdMessenger  cmdMessenger = CmdMessenger(Serial);
 unsigned long lastCommand;
@@ -81,6 +84,10 @@ void attachCommandCallbacks()
 
 #if MF_OUTPUT_SHIFTER_SUPPORT == 1
     cmdMessenger.attach(kSetShiftRegisterPins, OutputShifter::OnSet);
+#endif
+
+#if MF_CUSTOMDEVICE_SUPPORT == 1
+    cmdMessenger.attach(kSetCustomDevice, CustomDevice::OnSet);
 #endif
 
 #ifdef DEBUG2CMDMESSENGER

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -247,12 +247,6 @@ void readConfig()
     bool     copy_success = true;                            // will be set to false if copying input names to nameBuffer exceeds array dimensions
                                                              // not required anymore when pins instead of names are transferred to the UI
 
-    uint16_t length    = MFeeprom.get_length();
-    char     temp      = 0;
-    uint16_t adrPin    = 0;
-    uint16_t adrType   = 0;
-    uint16_t adrConfig = 0;
-
     if (command == 0) // just to be sure, configLength should also be 0
         return;
 
@@ -420,18 +414,18 @@ void readConfig()
 #endif
 
 #if MF_CUSTOMDEVICE_SUPPORT == 1
-        case kTypeCustomDevice:
-            adrType      = addreeprom; // first location of custom Type in EEPROM
+        case kTypeCustomDevice: {
+            uint16_t adrType      = addreeprom; // first location of custom Type in EEPROM
             copy_success = readEndCommandFromEEPROM(&addreeprom, '.');
             if (!copy_success)
                 break;
 
-            adrPin       = addreeprom; // first location of custom pins in EEPROM
+            uint16_t adrPin       = addreeprom; // first location of custom pins in EEPROM
             copy_success = readEndCommandFromEEPROM(&addreeprom, '.');
             if (!copy_success)
                 break;
 
-            adrConfig    = addreeprom; // first location of custom config in EEPROM
+            uint16_t adrConfig    = addreeprom; // first location of custom config in EEPROM
             copy_success = readEndCommandFromEEPROM(&addreeprom, '.');
             if (copy_success) {
                 CustomDevice::Add(adrPin, adrType, adrConfig);
@@ -439,6 +433,7 @@ void readConfig()
             }
             // cmdMessenger.sendCmd(kDebug, F("CustomDevice loaded"));
             break;
+        }
 #endif
 
         default:

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -1,0 +1,86 @@
+#include <Arduino.h>
+#include "CustomDevice.h"
+#include "MFCustomDevice.h"
+#include "commandmessenger.h"
+#include "MFBoards.h"
+#include "allocateMem.h"
+
+/* **********************************************************************************
+    Normally nothing has to be changed in this file
+    It handles one or multiple custom devices
+********************************************************************************** */
+namespace CustomDevice
+{
+    uint8_t         CustomDeviceRegistered = 0;
+    MFCustomDevice *customDevice[MAX_CUSTOM_DEVICES];
+
+    void Add(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+    {
+        if (CustomDeviceRegistered == MAX_CUSTOM_DEVICES)
+            return;
+        if (!FitInMemory(sizeof(MFCustomDevice))) {
+            // Error Message to Connector
+            cmdMessenger.sendCmd(kStatus, F("Custom Device does not fit in Memory"));
+            return;
+        }
+        customDevice[CustomDeviceRegistered] = new (allocateMemory(sizeof(MFCustomDevice))) MFCustomDevice(adrPin, adrType, adrConfig);
+        CustomDeviceRegistered++;
+#ifdef DEBUG2CMDMESSENGER
+        cmdMessenger.sendCmd(kStatus, F("Added Stepper Setpoint"));
+#endif
+    }
+
+    /* **********************************************************************************
+        All custom devives gets unregistered if a new config gets uploaded.
+        The Clear() function from every registerd custom device will be called.
+        Keep it as it is, mostly nothing must be changed
+    ********************************************************************************** */
+    void Clear()
+    {
+        for (int i = 0; i != CustomDeviceRegistered; i++) {
+            customDevice[i]->detach();
+        }
+        CustomDeviceRegistered = 0;
+#ifdef DEBUG2CMDMESSENGER
+        cmdMessenger.sendCmd(kStatus, F("Cleared Stepper Setpoint"));
+#endif
+    }
+
+    /* **********************************************************************************
+        Within in loop() the update() function is called regularly
+        Within the loop() you can define a time delay where this function gets called
+        or as fast as possible. See comments in loop()
+        The update() function from every registerd custom device will be called.
+        It is only needed if you have to update your custom device without getting
+        new values from the connector. Otherwise just make a return;
+    ********************************************************************************** */
+    void update()
+    {
+        for (int i = 0; i != CustomDeviceRegistered; i++) {
+            customDevice[i]->update();
+        }
+    }
+
+    /* **********************************************************************************
+        If an output for the custom device is defined in the connector,
+        this function gets called when a new value is available.
+        In this case the connector sends a messageID followed by a string which is not longer
+        than 90 Byte (!!check the length of the string!!) limited by the commandMessenger.
+        The messageID is used to mark the value which has changed. This reduced the serial
+        communication as not all values has to be send in one (big) string (like for the LCD)
+        The OnSet() function from every registerd custom device will be called.
+    ********************************************************************************** */
+    void OnSet()
+    {
+        int16_t device = cmdMessenger.readInt16Arg(); // get the device number
+        if (device >= CustomDeviceRegistered)         // and do nothing if this device is not registered
+            return;
+        int16_t messageID = cmdMessenger.readInt16Arg();  // get the messageID number
+        char   *output    = cmdMessenger.readStringArg(); // get the pointer to the new raw string
+        cmdMessenger.unescape(output);                    // and unescape the string if escape characters are used
+        customDevice[device]->set(messageID, output);     // send the string to your custom device
+
+        setLastCommandMillis();
+    }
+
+} // end of namespace

--- a/src/MF_CustomDevice/CustomDevice.h
+++ b/src/MF_CustomDevice/CustomDevice.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace CustomDevice
+{
+    void Add(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
+    void Clear();
+    void update();
+    void OnSet();
+}

--- a/src/commandmessenger.h
+++ b/src/commandmessenger.h
@@ -44,6 +44,7 @@ enum {
     kInputShifterChange,   // 29
     kDigInMuxChange,       // 30
     kSetStepperSpeedAccel, // 31
+    kSetCustomDevice,      // 32
     kDebug = 0xFF          // 255
 };
 

--- a/src/config.h
+++ b/src/config.h
@@ -22,7 +22,8 @@ enum {
     kTypeInputShifter,        // 12 Input shift register support (example: 74HC165)
     kTypeMuxDriver,           // 13 Multiplexer selector support (generates select outputs)
     kTypeDigInMux,            // 14 Digital input multiplexer support (example: 74HCT4067, 74HCT4051)
-    kTypeStepper              // new stepper type with settings for backlash and deactivate output
+    kTypeStepper,             // 15 new stepper type with settings for backlash and deactivate output
+    kTypeCustomDevice         // 16 Custom Device
 };
 
 void loadConfig(void);

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -32,6 +32,9 @@
 #if MF_DIGIN_MUX_SUPPORT == 1
 #include "DigInMux.h"
 #endif
+#if MF_CUSTOMDEVICE_SUPPORT == 1
+#include "CustomDevice.h"
+#endif
 
 #define MF_BUTTON_DEBOUNCE_MS     10 // time between updating the buttons
 #define MF_ENCODER_DEBOUNCE_MS    1  // time between encoder updates
@@ -66,6 +69,9 @@ typedef struct {
 #endif
 #if MF_DIGIN_MUX_SUPPORT == 1
     uint32_t DigInMux = 0;
+#endif
+#if MF_CUSTOMDEVICE_SUPPORT == 1
+    uint32_t CustomDevice = 0;
 #endif
 } lastUpdate_t;
 
@@ -196,6 +202,15 @@ void loop()
 #if MF_DIGIN_MUX_SUPPORT == 1
         timedUpdate(DigInMux::read, &lastUpdate.DigInMux, MF_INMUX_POLL_MS);
 #endif
+
+#if MF_CUSTOMDEVICE_SUPPORT == 1 && defined(MF_CUSTOMDEVICE_HAS_UPDATE)
+#ifdef MF_CUSTOMDEVICE_POLL_MS
+        timedUpdate(CustomDevice::update, &lastUpdate.CustomDevice, MF_CUSTOMDEVICE_POLL_MS);
+#else
+        CustomDevice::update();
+#endif
+#endif
+
         // lcds, outputs, outputshifters, segments do not need update
     }
 }


### PR DESCRIPTION
This PR adds support for custom devices. This makes it a lot of easier to implement own devices.
A defined interface for the data exchange is introduced.
There was already PR #214 which was closed as major changes are implemented in this new branch.

The code for custom devices will have an own repo, for now it's https://github.com/elral/MobiFlight-CustomDevices which must be transferred to Mobiflight when this PR gets merged. Additionally the script `get_CustomDevices.py` and the workflows `ci.yml` / `release.yml` must be adapted in this case. They point for now to my repo to get the PR compiled on github.

On first executing of `pio run [-e environment]` the repo for custom devices will be cloned into the folder `./CustomDevices`. On all next executing of `pio run [-e xyz]` this folder gets updated and all available custom devices gets compiled.

All the required code for a custom device must be in one folder. How to setup this code is explained in https://github.com/elral/MobiFlight-Connector/wiki/How-to-set-up-a-custom-device (which must also be transferred to the Mobiflight WiKi) and in a template under `./CustomDevices/_template/`.
To get it automatically compiled during a `pio run` the `platformio.ini` must be adapted with one additional line which points to an .ini file whithin the device folder.
Some examples are already included.

For the naming convention the names of the standard environments are changed. The `mobiflight` is now part of this environment and not anymore added by the `get_version.py` script. This enables to have firmware file names starting not only with mobiflight but also with a different name (most likely [company]name of the user/company).

The boards.h files are added for using custom devices. The config.cpp is added to read a config with custom devices. The commandmessenger.cpp is added with new functions to call the custom device functions.  A new folder `/src/CustomDevices` is added where the  basic functions to support custom devices are included. These files are always the same and must not be changed for a new custom device.
