### PR TITLE
TM1637 memory and code structure improvements

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -78,8 +78,7 @@ bool readConfigLength()
 
     while (MFeeprom.read_byte(addreeprom++) != 0x00) {
         configLength++;
-        if (addreeprom > length)
-        {
+        if (addreeprom > length) {
             cmdMessenger.sendCmd(kStatus, F("Loading config failed")); // text or "-1" like config upload?
             return false;
         }
@@ -209,8 +208,8 @@ bool readNameFromEEPROM(uint16_t *addreeprom, char *buffer, uint16_t *addrbuffer
         if (*addrbuffer >= MEMLEN_NAMES_BUFFER) {                      // nameBuffer will be exceeded
             return false;                                              // abort copying from EEPROM to nameBuffer
         }
-    } while (temp != ':');                                             // reads until limiter ':' and locates the next free buffer position
-    buffer[(*addrbuffer) - 1] = 0x00;                                  // replace ':' by NULL, terminates the string
+    } while (temp != ':');            // reads until limiter ':' and locates the next free buffer position
+    buffer[(*addrbuffer) - 1] = 0x00; // replace ':' by NULL, terminates the string
     return true;
 }
 
@@ -223,13 +222,13 @@ bool readEndCommandFromEEPROM(uint16_t *addreeprom)
         temp = MFeeprom.read_byte((*addreeprom)++);
         if (*addreeprom > length) // abort if EEPROM size will be exceeded
             return false;
-    } while (temp != ':');        // reads until limiter ':'
+    } while (temp != ':'); // reads until limiter ':'
     return true;
 }
 
 void readConfig()
 {
-    if (configLength == 0)                                   // do nothing if no config is available
+    if (configLength == 0) // do nothing if no config is available
         return;
     uint16_t addreeprom   = MEM_OFFSET_CONFIG;               // define first memory location where config is saved in EEPROM
     uint16_t addrbuffer   = 0;                               // and start with first memory location from nameBuffer
@@ -238,7 +237,7 @@ void readConfig()
     bool     copy_success = true;                            // will be set to false if copying input names to nameBuffer exceeds array dimensions
                                                              // not required anymore when pins instead of names are transferred to the UI
 
-    if (command == 0)                                        // just to be sure, configLength should also be 0
+    if (command == 0) // just to be sure, configLength should also be 0
         return;
 
     do // go through the EEPROM until it is NULL terminated
@@ -251,54 +250,55 @@ void readConfig()
             break;
 
         case kTypeOutput:
-            params[0] = readUintFromEEPROM(&addreeprom);          // Pin number
+            params[0] = readUintFromEEPROM(&addreeprom); // Pin number
             Output::Add(params[0]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
 
 #if MF_SEGMENT_SUPPORT == 1
-        case kTypeLedSegment:
-            params[0] = readUintFromEEPROM(&addreeprom);          // Pin Data number
-            params[1] = readUintFromEEPROM(&addreeprom);          // Pin CS number
-            params[2] = readUintFromEEPROM(&addreeprom);          // Pin CLK number
-            params[3] = readUintFromEEPROM(&addreeprom);          // brightness
-            params[4] = readUintFromEEPROM(&addreeprom);          // number of modules
-            LedSegment::Add(params[0], params[1], params[2], params[4], params[3]);
+        // this is for backwards compatibility
+        case kTypeLedSegmentDeprecated:
+        // this is the new type
+        case kTypeLedSegmentMulti:
+            params[0] = LedSegment::TYPE_MAX72XX;
+            if (command == kTypeLedSegmentMulti)
+                params[0] = readUintFromEEPROM(&addreeprom); // Type of LedSegment
+
+            params[1] = readUintFromEEPROM(&addreeprom); // Pin Data number
+            params[2] = readUintFromEEPROM(&addreeprom); // Pin CS number
+            params[3] = readUintFromEEPROM(&addreeprom); // Pin CLK number
+            params[4] = readUintFromEEPROM(&addreeprom); // brightness
+            params[5] = readUintFromEEPROM(&addreeprom); // number of modules
+            LedSegment::Add(params[0], params[1], params[2], params[3], params[5], params[4]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
 #endif
 
 #if MF_STEPPER_SUPPORT == 1
         case kTypeStepperDeprecated1:
-            // this is for backwards compatibility
-            params[0] = readUintFromEEPROM(&addreeprom);          // Pin1 number
-            params[1] = readUintFromEEPROM(&addreeprom);          // Pin2 number
-            params[2] = readUintFromEEPROM(&addreeprom);          // Pin3 number
-            params[3] = readUintFromEEPROM(&addreeprom);          // Pin4 number
-            params[4] = readUintFromEEPROM(&addreeprom);          // Button number
-            Stepper::Add(params[0], params[1], params[2], params[3], 0);
-            copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
-            break;
-
         case kTypeStepperDeprecated2:
-            params[0] = readUintFromEEPROM(&addreeprom);          // Pin1 number
-            params[1] = readUintFromEEPROM(&addreeprom);          // Pin2 number
-            params[2] = readUintFromEEPROM(&addreeprom);          // Pin3 number
-            params[3] = readUintFromEEPROM(&addreeprom);          // Pin4 number
-            params[4] = readUintFromEEPROM(&addreeprom);          // Button number
-            Stepper::Add(params[0], params[1], params[2], params[3], params[4]);
-            copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
-            break;
-
         case kTypeStepper:
+            // Values for all stepper types
             params[0] = readUintFromEEPROM(&addreeprom); // Pin1 number
             params[1] = readUintFromEEPROM(&addreeprom); // Pin2 number
             params[2] = readUintFromEEPROM(&addreeprom); // Pin3 number
             params[3] = readUintFromEEPROM(&addreeprom); // Pin4 number
-            params[4] = readUintFromEEPROM(&addreeprom); // Button number
-            params[5] = readUintFromEEPROM(&addreeprom); // Stepper Mode
-            params[6] = readUintFromEEPROM(&addreeprom); // backlash
-            params[7] = readUintFromEEPROM(&addreeprom); // deactivate output
+
+            // Default values for older types
+            params[4] = (uint8_t)0; // Button number
+            params[5] = (uint8_t)0; // Stepper Mode
+            params[6] = (uint8_t)0; // backlash
+            params[7] = false;      // deactivate output
+
+            if (command == kTypeStepperDeprecated2) {
+                params[4] = readUintFromEEPROM(&addreeprom); // Button number
+            }
+
+            if (command == kTypeStepper) {
+                params[5] = readUintFromEEPROM(&addreeprom); // Stepper Mode
+                params[6] = readUintFromEEPROM(&addreeprom); // backlash
+                params[7] = readUintFromEEPROM(&addreeprom); // deactivate output
+            }
             // there is an additional 9th parameter stored in the config (profileID) which is not needed in the firmware
             // and therefor not read in, it is just skipped like the name with reading until end of command
             Stepper::Add(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]);
@@ -308,7 +308,7 @@ void readConfig()
 
 #if MF_SERVO_SUPPORT == 1
         case kTypeServo:
-            params[0] = readUintFromEEPROM(&addreeprom);          // Pin number
+            params[0] = readUintFromEEPROM(&addreeprom); // Pin number
             Servos::Add(params[0]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
@@ -333,9 +333,9 @@ void readConfig()
 
 #if MF_LCD_SUPPORT == 1
         case kTypeLcdDisplayI2C:
-            params[0] = readUintFromEEPROM(&addreeprom);          // address
-            params[1] = readUintFromEEPROM(&addreeprom);          // columns
-            params[2] = readUintFromEEPROM(&addreeprom);          // lines
+            params[0] = readUintFromEEPROM(&addreeprom); // address
+            params[1] = readUintFromEEPROM(&addreeprom); // columns
+            params[2] = readUintFromEEPROM(&addreeprom); // lines
             LCDDisplay::Add(params[0], params[1], params[2]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
@@ -353,10 +353,10 @@ void readConfig()
 
 #if MF_OUTPUT_SHIFTER_SUPPORT == 1
         case kTypeOutputShifter:
-            params[0] = readUintFromEEPROM(&addreeprom);          // latch Pin
-            params[1] = readUintFromEEPROM(&addreeprom);          // clock Pin
-            params[2] = readUintFromEEPROM(&addreeprom);          // data Pin
-            params[3] = readUintFromEEPROM(&addreeprom);          // number of daisy chained modules
+            params[0] = readUintFromEEPROM(&addreeprom); // latch Pin
+            params[1] = readUintFromEEPROM(&addreeprom); // clock Pin
+            params[2] = readUintFromEEPROM(&addreeprom); // data Pin
+            params[3] = readUintFromEEPROM(&addreeprom); // number of daisy chained modules
             OutputShifter::Add(params[0], params[1], params[2], params[3]);
             copy_success = readEndCommandFromEEPROM(&addreeprom); // check EEPROM until end of name
             break;
@@ -364,10 +364,10 @@ void readConfig()
 
 #if MF_INPUT_SHIFTER_SUPPORT == 1
         case kTypeInputShifter:
-            params[0] = readUintFromEEPROM(&addreeprom);                             // latch Pin
-            params[1] = readUintFromEEPROM(&addreeprom);                             // clock Pin
-            params[2] = readUintFromEEPROM(&addreeprom);                             // data Pin
-            params[3] = readUintFromEEPROM(&addreeprom);                             // number of daisy chained modules
+            params[0] = readUintFromEEPROM(&addreeprom); // latch Pin
+            params[1] = readUintFromEEPROM(&addreeprom); // clock Pin
+            params[2] = readUintFromEEPROM(&addreeprom); // data Pin
+            params[3] = readUintFromEEPROM(&addreeprom); // number of daisy chained modules
             InputShifter::Add(params[0], params[1], params[2], params[3], &nameBuffer[addrbuffer]);
             copy_success = readNameFromEEPROM(&addreeprom, nameBuffer, &addrbuffer); // copy the NULL terminated name to to nameBuffer and set to next free memory location
                                                                                      //    copy_success = readEndCommandFromEEPROM(&addreeprom);       // once the nameBuffer is not required anymore uncomment this line and delete the line before

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -315,20 +315,16 @@ void readConfig()
 #endif
 
         case kTypeEncoderSingleDetent:
-            params[0] = readUintFromEEPROM(&addreeprom);                             // Pin1 number
-            params[1] = readUintFromEEPROM(&addreeprom);                             // Pin2 number
-            Encoder::Add(params[0], params[1], 0, &nameBuffer[addrbuffer]);          // MUST be before readNameFromEEPROM because readNameFromEEPROM returns the pointer for the NEXT Name
-            copy_success = readNameFromEEPROM(&addreeprom, nameBuffer, &addrbuffer); // copy the NULL terminated name to nameBuffer and set to next free memory location
-                                                                                     //    copy_success = readEndCommandFromEEPROM(&addreeprom);       // once the nameBuffer is not required anymore uncomment this line and delete the line before
-            break;
-
         case kTypeEncoder:
-            params[0] = readUintFromEEPROM(&addreeprom);                             // Pin1 number
-            params[1] = readUintFromEEPROM(&addreeprom);                             // Pin2 number
-            params[2] = readUintFromEEPROM(&addreeprom);                             // type
+            params[0] = readUintFromEEPROM(&addreeprom); // Pin1 number
+            params[1] = readUintFromEEPROM(&addreeprom); // Pin2 number
+            params[2] = 0;                               // type
+
+            if (command == kTypeEncoder)
+                params[2] = readUintFromEEPROM(&addreeprom); // type
+
             Encoder::Add(params[0], params[1], params[2], &nameBuffer[addrbuffer]);  // MUST be before readNameFromEEPROM because readNameFromEEPROM returns the pointer for the NEXT Name
-            copy_success = readNameFromEEPROM(&addreeprom, nameBuffer, &addrbuffer); // copy the NULL terminated name to to nameBuffer and set to next free memory location
-                                                                                     //    copy_success = readEndCommandFromEEPROM(&addreeprom);       // once the nameBuffer is not required anymore uncomment this line and delete the line before
+            copy_success = readNameFromEEPROM(&addreeprom, nameBuffer, &addrbuffer); // copy the NULL terminated name to nameBuffer and set to next free memory location
             break;
 
 #if MF_LCD_SUPPORT == 1

--- a/src/MF_Segment/LedControl_dual.cpp
+++ b/src/MF_Segment/LedControl_dual.cpp
@@ -1,26 +1,10 @@
-// =======================================================================
-// @file        LedControl_dual.cpp
 //
-// @project     MobiFlight custom Firmware
+// LedControl_dual.cpp
 //
-// @author      GiorgioCC (g.crocic@gmail.com) - 2023-06-29
-// @modifiedby  GiorgioCC - 2023-07-09 20:13
+// (C) MobiFlight Project 2023
 //
-// A library for controlling LED 7-segment displays with either
-// a MAX7219/MAX7221 or a TM1637 (4/6 digit) driver
-// Portions of code derived from:
-// - LedControl - A library for controlling Leds with a MAX7219/MAX7221
-//   Copyright (c) 2007 Eberhard Fahle
-// - TM1637TinyDisplay - TM1637 Tiny Display library by Jason A. Cox
-//   (https://github.com/jasonacox)
-//
-// =======================================================================
 
 #include "LedControl_dual.h"
-
-// =======================================================================
-// Common Definitions
-// =======================================================================
 
 // Segments to be switched on for characters and digits on 7-Segment Displays
 // bit/segment sequence: dABCDEFG
@@ -154,7 +138,7 @@ void LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t cs
     IO_DTA     = dataPin;
     IO_CLK     = clkPin;
     IO_CS      = csPin;
-    
+
     if (isMAX()) {
         if ((numDevices - 1) > 7) numDevices = 8;
         maxUnits = numDevices;

--- a/src/MF_Segment/LedControl_dual.cpp
+++ b/src/MF_Segment/LedControl_dual.cpp
@@ -148,17 +148,13 @@ uint8_t LedControl::rawdata[16] = {0};
 // Digit sequence map for 6 digit displays
 const uint8_t digitmap[] = {2, 1, 0, 5, 4, 3};
 
-// Configuration:
-// csPin < 0xFD -> MAX72xx
-// csPin = 0xFD -> TM1637 4-digit
-// csPin = 0xFE -> TM1637 6-digit
-// csPin = 0xFF -> uninitialized
 void LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t csPin, uint8_t numDevices)
 {
     this->type = type;
     IO_DTA     = dataPin;
     IO_CLK     = clkPin;
     IO_CS      = csPin;
+    
     if (isMAX()) {
         if ((numDevices - 1) > 7) numDevices = 8;
         maxUnits = numDevices;

--- a/src/MF_Segment/LedControl_dual.h
+++ b/src/MF_Segment/LedControl_dual.h
@@ -62,10 +62,10 @@ class LedControl
 {
 private:
     // Common
-    uint8_t type   = TYPE_UNDEFINED;
-    uint8_t IO_DTA = TYPE_UNDEFINED;
-    uint8_t IO_CLK = TYPE_UNDEFINED;
-    uint8_t IO_CS  = TYPE_UNDEFINED;
+    uint8_t _type    = TYPE_UNDEFINED;
+    uint8_t _dataPin = TYPE_UNDEFINED;
+    uint8_t _clkPin  = TYPE_UNDEFINED;
+    uint8_t _csPin   = TYPE_UNDEFINED;
     // MAX: Number of chained units
     // TM:  Number of digits (4 or 6)
 #ifdef LEDCONTROL_NO_BUF
@@ -105,7 +105,7 @@ public:
 
     void begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t csPin, uint8_t numDevices = 1);
 
-    bool    isMAX(void) { return type == LedSegment::TYPE_MAX72XX; }
+    bool    isMAX(void) { return _type == LedSegment::TYPE_MAX72XX; }
     uint8_t getDeviceCount(void) { return (isMAX() ? maxUnits : 1); };
     uint8_t getDigitCount(void) { return (isMAX() ? 8 : maxUnits); };
 

--- a/src/MF_Segment/LedControl_dual.h
+++ b/src/MF_Segment/LedControl_dual.h
@@ -33,12 +33,12 @@
 #define __LEDCONTROL_DUAL__H__
 
 // This constant reduces buffer usage: a single (static) 16-byte buffer
-// is used for all objects. However, for TM1637s, data is written 
-// byte-by-byte, making transmission of data blocks slower. 
-//#define LEDCONTROL_NO_BUF
+// is used for all objects. However, for TM1637s, data is written
+// byte-by-byte, making transmission of data blocks slower.
+// #define LEDCONTROL_NO_BUF
 
 // This constant adds methods to print a decimal/hex number or a string
-// (as opposite to writing individual chars). 
+// (as opposite to writing individual chars).
 #define LEDCONTROL_EXTENDED
 
 #include <stdint.h>
@@ -46,12 +46,12 @@
 #include <Arduino.h>
 
 #ifdef __AVR__
-    #include <avr/pgmspace.h>
+#include <avr/pgmspace.h>
 #elif defined(ESP8266) || defined(ESP32)
-    #include <pgmspace.h>
+#include <pgmspace.h>
 #else
-    #define pgm_read_byte(addr) \
-        (*(const unsigned char *)(addr)) // workaround for non-AVR
+#define pgm_read_byte(addr) \
+    (*(const unsigned char *)(addr)) // workaround for non-AVR
 #endif
 
 // =======================================================================
@@ -65,58 +65,64 @@
 class LedControl
 {
 public:
-    enum { TM_4D = 0xFD, TM_6D = 0xFE, UNINITIALIZED = 0xFF};
-    enum { ZERO_BRIGHTNESS = 0, MIN_BRIGHTNESS = 1, MAX_BRIGHTNESS = 15 };
+    enum { TYPE_MAX72XX        = 0,
+           TYPE_TM1637_4DIGITS = 0xFD,
+           TYPE_TM1637_6DIGITS = 0xFE,
+           TYPE_UNDEFINED      = 0xFF };
+    enum { ZERO_BRIGHTNESS = 0,
+           MIN_BRIGHTNESS  = 1,
+           MAX_BRIGHTNESS  = 15 };
 
 private:
     // Common
-    uint8_t IO_DTA = UNINITIALIZED;
-    uint8_t IO_CLK = UNINITIALIZED;
-    uint8_t IO_CS  = UNINITIALIZED;
+    uint8_t type   = TYPE_UNDEFINED;
+    uint8_t IO_DTA = TYPE_UNDEFINED;
+    uint8_t IO_CLK = TYPE_UNDEFINED;
+    uint8_t IO_CS  = TYPE_UNDEFINED;
     // MAX: Number of chained units
     // TM:  Number of digits (4 or 6)
 #ifdef LEDCONTROL_NO_BUF
-    // For TM, buffer can't be static (= shared): either we are building 
-    // the extended version (which adds a per-unit buffer instead of the static one) 
+    // For TM, buffer can't be static (= shared): either we are building
+    // the extended version (which adds a per-unit buffer instead of the static one)
     // or we are forced to resort to digit-by-digit output
     static
 #endif
-    uint8_t rawdata[16];    
-    uint8_t maxUnits   = 0; // MAX: N. of chained units; TM: N. of digits
-    uint8_t brightness = MAX_BRIGHTNESS;
-    void    setPattern(uint8_t addr, uint8_t digit, uint8_t value, bool sendNow = true);
+        uint8_t rawdata[16];
+    uint8_t     maxUnits   = 0; // MAX: N. of chained units; TM: N. of digits
+    uint8_t     brightness = MAX_BRIGHTNESS;
+    void        setPattern(uint8_t addr, uint8_t digit, uint8_t value, bool sendNow = true);
 
     // MAX-specific
-    void    setScanLimit(uint8_t addr, uint8_t limit);
-    void    spiTransfer(uint8_t addr, uint8_t opcode, uint8_t data);
+    void setScanLimit(uint8_t addr, uint8_t limit);
+    void spiTransfer(uint8_t addr, uint8_t opcode, uint8_t data);
 
     // TM-specific
     // uint8_t dpSet = 0;
-    void    bitDelay() { delayMicroseconds(DEFAULT_BIT_DELAY); };
-    void    start(void);
-    void    stop(void);
-    bool    writeByte(uint8_t data, bool rvs = false);
+    void bitDelay() { delayMicroseconds(DEFAULT_BIT_DELAY); };
+    void start(void);
+    void stop(void);
+    bool writeByte(uint8_t data, bool rvs = false);
 
 #ifdef LEDCONTROL_NO_BUF
-    void    writeOneDigit(uint8_t ndigit, uint8_t val); 
+    void writeOneDigit(uint8_t ndigit, uint8_t val);
 #else
     // Has buffer available
-    void    writeDigits(uint8_t ndigit, uint8_t len);
-    void    writeBuffer(void) { writeDigits(maxUnits-1, maxUnits); };
+    void writeDigits(uint8_t ndigit, uint8_t len);
+    void writeBuffer(void) { writeDigits(maxUnits - 1, maxUnits); };
 #endif
 
 public:
-    LedControl() {};
+    LedControl(){};
 
-    void    begin(uint8_t dataPin, uint8_t clkPin, uint8_t csPin, uint8_t numDevices = 1);
+    void begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t csPin, uint8_t numDevices = 1);
 
-    bool    isMAX(void) { return (IO_CS + 1) < TM_6D; }
+    bool    isMAX(void) { return type == TYPE_MAX72XX; }
     uint8_t getDeviceCount(void) { return (isMAX() ? maxUnits : 1); };
     uint8_t getDigitCount(void) { return (isMAX() ? 8 : maxUnits); };
 
-    void    shutdown(uint8_t addr, bool status);
-    void    setIntensity(uint8_t addr, uint8_t intensity);
-    void    clearDisplay(uint8_t addr = 0);
+    void shutdown(uint8_t addr, bool status);
+    void setIntensity(uint8_t addr, uint8_t intensity);
+    void clearDisplay(uint8_t addr = 0);
 
     // Display a hexadecimal digit.
     // Params:
@@ -124,10 +130,10 @@ public:
     // digit	the position of the digit on the display (0 is RIGHTMOST)
     // value	the value to be displayed. (0x00..0x0F)
     // dp	    sets the decimal point.
-    // sendnow  If false, buffers chars rather than sending them immediately (TM only; 
+    // sendnow  If false, buffers chars rather than sending them immediately (TM only;
     //          requires a sendAll() afterwards).
     //          Ignored for MAX, or if LEDCONTROL_NO_BUF is defined.
-    void    setDigit(uint8_t addr, uint8_t digit, uint8_t value, bool dp = false, bool sendNow = true);
+    void setDigit(uint8_t addr, uint8_t digit, uint8_t value, bool dp = false, bool sendNow = true);
 
     // Display a character.
     // There are only a few characters that make sense here :
@@ -139,14 +145,14 @@ public:
     // digit	the position of the character on the display (0 is RIGHTMOST)
     // value	the character to be displayed.
     // dp	    sets the decimal point.
-    // sendnow  If false, buffers chars rather than sending them immediately (TM only; 
+    // sendnow  If false, buffers chars rather than sending them immediately (TM only;
     //          requires a sendAll() afterwards).
     //          Ignored for MAX, or if LEDCONTROL_NO_BUF is defined.
-    void    setChar(uint8_t addr, uint8_t digit, char value, bool dp = false, bool sendNow = true);
+    void setChar(uint8_t addr, uint8_t digit, char value, bool dp = false, bool sendNow = true);
 
 #ifndef LEDCONTROL_NO_BUF
     // Sends the whole (previously filled) buffer content.
-    void    sendAll(void) { writeBuffer(); };
+    void sendAll(void) { writeBuffer(); };
 #endif
 
 #ifdef LEDCONTROL_EXTENDED
@@ -163,8 +169,8 @@ public:
     // @param leading_zero When true, leading zeros are displayed. Otherwise unnecessary digits are
     //        blank.
     // @param rstart The position of the LEAST significant digit (N-1 = leftmost, 0 = rightmost)
-    void    showNumber(uint8_t addr, int32_t num, bool isHex = false, uint8_t dots = 0, 
-                       bool leading_zero = false, uint8_t roffset = 0);
+    void showNumber(uint8_t addr, int32_t num, bool isHex = false, uint8_t dots = 0,
+                    bool leading_zero = false, uint8_t roffset = 0);
 
     // Display a string
     //
@@ -176,11 +182,10 @@ public:
     // @param dots Dot/Colon enable. The argument is a bitmask, with each bit corresponding to a dot
     //        between the digits (LEFT aligned)
     // See showString_P function for reading PROGMEM read-only flash memory space instead of RAM
-    void    showString(uint8_t addr, char* s, uint8_t loffset = 0, uint8_t dots = 0);
-    //void    showString_P(uint8_t addr, const char s[], uint8_t pos = 0, uint8_t dots = 0);
+    void showString(uint8_t addr, char *s, uint8_t loffset = 0, uint8_t dots = 0);
+    // void    showString_P(uint8_t addr, const char s[], uint8_t pos = 0, uint8_t dots = 0);
 
 #endif
-
 };
 
 #endif //!__LEDCONTROL_DUAL__H__

--- a/src/MF_Segment/LedControl_dual.h
+++ b/src/MF_Segment/LedControl_dual.h
@@ -44,6 +44,7 @@
 #include <stdint.h>
 // #include <inttypes.h>
 #include <Arduino.h>
+#include <LedSegment.h>
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>
@@ -59,20 +60,13 @@
 // =======================================================================
 
 #define DEFAULT_BIT_DELAY 100
+#define TYPE_UNDEFINED    0xFF
+#define MAX_BRIGHTNESS    15
 
 // =======================================================================
 
 class LedControl
 {
-public:
-    enum { TYPE_MAX72XX        = 0,
-           TYPE_TM1637_4DIGITS = 0xFD,
-           TYPE_TM1637_6DIGITS = 0xFE,
-           TYPE_UNDEFINED      = 0xFF };
-    enum { ZERO_BRIGHTNESS = 0,
-           MIN_BRIGHTNESS  = 1,
-           MAX_BRIGHTNESS  = 15 };
-
 private:
     // Common
     uint8_t type   = TYPE_UNDEFINED;
@@ -85,12 +79,14 @@ private:
     // For TM, buffer can't be static (= shared): either we are building
     // the extended version (which adds a per-unit buffer instead of the static one)
     // or we are forced to resort to digit-by-digit output
-    static
+    static uint8_t rawdata[16];
+#else
+    uint8_t rawdata[16];
 #endif
-        uint8_t rawdata[16];
-    uint8_t     maxUnits   = 0; // MAX: N. of chained units; TM: N. of digits
-    uint8_t     brightness = MAX_BRIGHTNESS;
-    void        setPattern(uint8_t addr, uint8_t digit, uint8_t value, bool sendNow = true);
+
+    uint8_t maxUnits   = 0; // MAX: N. of chained units; TM: N. of digits
+    uint8_t brightness = MAX_BRIGHTNESS;
+    void    setPattern(uint8_t addr, uint8_t digit, uint8_t value, bool sendNow = true);
 
     // MAX-specific
     void setScanLimit(uint8_t addr, uint8_t limit);
@@ -116,7 +112,7 @@ public:
 
     void begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t csPin, uint8_t numDevices = 1);
 
-    bool    isMAX(void) { return type == TYPE_MAX72XX; }
+    bool    isMAX(void) { return type == LedSegment::TYPE_MAX72XX; }
     uint8_t getDeviceCount(void) { return (isMAX() ? maxUnits : 1); };
     uint8_t getDigitCount(void) { return (isMAX() ? 8 : maxUnits); };
 

--- a/src/MF_Segment/LedControl_dual.h
+++ b/src/MF_Segment/LedControl_dual.h
@@ -1,33 +1,26 @@
-// =======================================================================
-// @file        LedControl_dual.h
 //
-// @project     MobiFlight custom Firmware
+// LedControl_dual.cpp
 //
-// @author      GiorgioCC (g.crocic@gmail.com) - 2023-06-29
-// @modifiedby  GiorgioCC - 2023-07-04 15:45
+// (C) MobiFlight Project 2023
 //
-// A library for controlling LED 7-segment displays with either
-// a MAX7219/MAX7221 or a TM1637 (4/6 digit) driver
+// @author GiorgioCC (g.crocic@gmail.com) - 2023-06-29
+//
+// Remarks:
+//
 // Portions of code derived from:
 // - LedControl - A library for controlling Leds with a MAX7219/MAX7221
 //   Copyright (c) 2007 Eberhard Fahle
 // - TM1637TinyDisplay - TM1637 Tiny Display library by Jason A. Cox
 //   (https://github.com/jasonacox)
-//
 // =======================================================================
 // This is basically a mix of two drivers in the same library (with common
 // code parts factorized as much as possible):
-// the type of driver to be used is determined with the value passed for
-// the <csPin> argument in the begin() call.
-// Since the TM1637 does not use a CS line, special values (which are
-// invalid for a MAX72xx) are used to configure the display as a TM1637.
-// Specifically, csPin = 0xFD -> TM1637 4-digit, 0xFE -> TM1637 6-digit
+// the type of driver is determined by the first argument in constructor
 // =======================================================================
 // Method signatures (and purpose) have been kept exactly as in the original
 // LedControl library used in MF firmware, so the interface doesn't change;
 // non-relevant arguments (particularly: <addr> for TM's) are ignored.
 // A few methods (mostly for internal use) have been added.
-//
 
 #ifndef __LEDCONTROL_DUAL__H__
 #define __LEDCONTROL_DUAL__H__

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -13,7 +13,7 @@ namespace LedSegment
     MFSegments *ledSegments[MAX_LEDSEGMENTS];
     uint8_t     ledSegmentsRegistered = 0;
 
-    void        Add(int dataPin, int csPin, int clkPin, int numDevices, int brightness)
+    void Add(uint8_t type, uint8_t dataPin, uint8_t csPin, uint8_t clkPin, uint8_t numDevices, uint8_t brightness)
     {
         if (ledSegmentsRegistered == MAX_LEDSEGMENTS)
             return;
@@ -24,7 +24,7 @@ namespace LedSegment
             return;
         }
         ledSegments[ledSegmentsRegistered] = new (allocateMemory(sizeof(MFSegments))) MFSegments;
-        ledSegments[ledSegmentsRegistered]->attach(dataPin, csPin, clkPin, numDevices, brightness); // lc is our object
+        ledSegments[ledSegmentsRegistered]->attach(type, dataPin, csPin, clkPin, numDevices, brightness); // lc is our object
         ledSegmentsRegistered++;
 #ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kDebug, F("Added Led Segment"));

--- a/src/MF_Segment/LedSegment.h
+++ b/src/MF_Segment/LedSegment.h
@@ -8,7 +8,14 @@
 
 namespace LedSegment
 {
-    void Add(int dataPin, int csPin, int clkPin, int numDevices, int brightness);
+    enum {
+        TYPE_MAX72XX        = 0,
+        TYPE_TM1637_4DIGITS = 0xFD,
+        TYPE_TM1637_6DIGITS = 0xFE,
+        TYPE_UNDEFINED      = 0xFF
+    };
+
+    void Add(uint8_t type, uint8_t dataPin, uint8_t csPin, uint8_t clkPin, uint8_t numDevices, uint8_t brightness);
     void Clear();
     void PowerSave(bool state);
     void OnInitModule();

--- a/src/MF_Segment/MFSegments.cpp
+++ b/src/MF_Segment/MFSegments.cpp
@@ -40,9 +40,9 @@ void MFSegments::setBrightness(byte module, byte value)
     }
 }
 
-void MFSegments::attach(int dataPin, int csPin, int clkPin, byte moduleCount, byte brightness)
+void MFSegments::attach(byte type, int dataPin, int csPin, int clkPin, byte moduleCount, byte brightness)
 {
-    _ledControl.begin(dataPin, clkPin, csPin, moduleCount);
+    _ledControl.begin(type, dataPin, clkPin, csPin, moduleCount);
     _moduleCount = moduleCount;
     for (uint8_t i = 0; i < _moduleCount; ++i) {
         setBrightness(i, brightness);

--- a/src/MF_Segment/MFSegments.h
+++ b/src/MF_Segment/MFSegments.h
@@ -14,7 +14,7 @@ class MFSegments
 public:
     MFSegments();
     void display(byte module, char *string, byte points, byte mask, bool convertPoints = false);
-    void attach(int dataPin, int csPin, int clkPin, byte moduleCount, byte brightness);
+    void attach(byte type, int dataPin, int csPin, int clkPin, byte moduleCount, byte brightness);
     void detach();
     void test();
     void powerSavingMode(bool state);

--- a/src/config.h
+++ b/src/config.h
@@ -7,22 +7,23 @@
 #pragma once
 
 enum {
-    kTypeNotSet,              // 0
-    kTypeButton,              // 1
-    kTypeEncoderSingleDetent, // 2 (retained for backwards compatibility, use kTypeEncoder for new configs)
-    kTypeOutput,              // 3
-    kTypeLedSegment,          // 4
-    kTypeStepperDeprecated1,  // 5 (keep for backwards compatibility, doesn't support autohome)
-    kTypeServo,               // 6
-    kTypeLcdDisplayI2C,       // 7
-    kTypeEncoder,             // 8
-    kTypeStepperDeprecated2,  // 9 (keep for backwards compatibility, stepper type with auto zero support if btnPin is > 0)
-    kTypeOutputShifter,       // 10 Shift register support (example: 74HC595, TLC592X)
-    kTypeAnalogInput,         // 11 Analog Device with 1 pin
-    kTypeInputShifter,        // 12 Input shift register support (example: 74HC165)
-    kTypeMuxDriver,           // 13 Multiplexer selector support (generates select outputs)
-    kTypeDigInMux,            // 14 Digital input multiplexer support (example: 74HCT4067, 74HCT4051)
-    kTypeStepper              // new stepper type with settings for backlash and deactivate output
+    kTypeNotSet,               // 0
+    kTypeButton,               // 1
+    kTypeEncoderSingleDetent,  // 2 (retained for backwards compatibility, use kTypeEncoder for new configs)
+    kTypeOutput,               // 3
+    kTypeLedSegmentDeprecated, // 4 (keep for backwards compatibility)
+    kTypeStepperDeprecated1,   // 5 (keep for backwards compatibility, doesn't support autohome)
+    kTypeServo,                // 6
+    kTypeLcdDisplayI2C,        // 7
+    kTypeEncoder,              // 8
+    kTypeStepperDeprecated2,   // 9 (keep for backwards compatibility, stepper type with auto zero support if btnPin is > 0)
+    kTypeOutputShifter,        // 10 Shift register support (example: 74HC595, TLC592X)
+    kTypeAnalogInput,          // 11 Analog Device with 1 pin
+    kTypeInputShifter,         // 12 Input shift register support (example: 74HC165)
+    kTypeMuxDriver,            // 13 Multiplexer selector support (generates select outputs)
+    kTypeDigInMux,             // 14 Digital input multiplexer support (example: 74HCT4067, 74HCT4051)
+    kTypeStepper,              // 15 new stepper type with settings for backlash and deactivate output
+    kTypeLedSegmentMulti       // 16 new led segment with MAX7219 and TM1637 support
 };
 
 void loadConfig(void);


### PR DESCRIPTION
## Description of changes

Fixes #251 

_Describe changes here_

- Introduced type instead of using the CS pin
- Memory improvements.

### Before (pro micro)
```
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [========  ]  77.3% (used 1978 bytes from 2560 bytes)
Flash: [==========]  99.9% (used 28630 bytes from 28672 bytes)
```

### After
```
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [========  ]  77.3% (used 1978 bytes from 2560 bytes)
Flash: [==========]  99.1% (used 28422 bytes from 28672 bytes)
```
