### PR TITLE
Fix board files

### DIFF
--- a/_Boards/Atmel/Board_Mega/MFBoards.h
+++ b/_Boards/Atmel/Board_Mega/MFBoards.h
@@ -82,9 +82,6 @@
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Mega"
 #endif
-#ifndef EEPROM_SIZE
-#define EEPROM_SIZE         4096 // EEPROMSizeMega
-#endif
 #ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG       1496 // max. size for config which wil be stored in EEPROM
 #endif

--- a/_Boards/Atmel/Board_Mega/MFBoards.h
+++ b/_Boards/Atmel/Board_Mega/MFBoards.h
@@ -35,9 +35,6 @@
 #define MF_MUX_SUPPORT       1
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
-#ifndef MF_CUSTOMDEVICE_SUPPORT
-#define MF_CUSTOMDEVICE_SUPPORT 1
-#endif
 
 #ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         40

--- a/_Boards/Atmel/Board_Nano/MFBoards.h
+++ b/_Boards/Atmel/Board_Nano/MFBoards.h
@@ -35,9 +35,6 @@
 #define MF_MUX_SUPPORT       1
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
-#ifndef MF_CUSTOMDEVICE_SUPPORT
-#define MF_CUSTOMDEVICE_SUPPORT 2
-#endif
 
 #ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18

--- a/_Boards/Atmel/Board_Nano/MFBoards.h
+++ b/_Boards/Atmel/Board_Nano/MFBoards.h
@@ -82,9 +82,6 @@
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Nano"
 #endif
-#ifndef EEPROM_SIZE
-#define EEPROM_SIZE         1024 // EEPROMSizeUno
-#endif
 #ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG       286  // max. size for config which wil be stored in EEPROM
 #endif

--- a/_Boards/Atmel/Board_ProMicro/MFBoards.h
+++ b/_Boards/Atmel/Board_ProMicro/MFBoards.h
@@ -35,9 +35,6 @@
 #define MF_MUX_SUPPORT       1
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
-#ifndef MF_CUSTOMDEVICE_SUPPORT
-#define MF_CUSTOMDEVICE_SUPPORT 2
-#endif
 
 #ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18

--- a/_Boards/Atmel/Board_ProMicro/MFBoards.h
+++ b/_Boards/Atmel/Board_ProMicro/MFBoards.h
@@ -82,9 +82,6 @@
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Micro"
 #endif
-#ifndef EEPROM_SIZE
-#define EEPROM_SIZE         1024 // EEPROMSizeMicro
-#endif
 #ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG       440  // max. size for config which wil be stored in EEPROM
 #endif

--- a/_Boards/Atmel/Board_Uno/MFBoards.h
+++ b/_Boards/Atmel/Board_Uno/MFBoards.h
@@ -35,9 +35,6 @@
 #define MF_MUX_SUPPORT       1
 #define MF_DIGIN_MUX_SUPPORT 1
 #endif
-#ifndef MF_CUSTOMDEVICE_SUPPORT
-#define MF_CUSTOMDEVICE_SUPPORT 2
-#endif
 
 #ifndef MAX_OUTPUTS
 #define MAX_OUTPUTS         18

--- a/_Boards/Atmel/Board_Uno/MFBoards.h
+++ b/_Boards/Atmel/Board_Uno/MFBoards.h
@@ -82,9 +82,6 @@
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Uno"
 #endif
-#ifndef EEPROM_SIZE
-#define EEPROM_SIZE         1024 // EEPROMSizeUno
-#endif
 #ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG       286  // max. size for config which wil be stored in EEPROM
 #endif

--- a/_Boards/RaspberryPi/Pico/MFBoards.h
+++ b/_Boards/RaspberryPi/Pico/MFBoards.h
@@ -76,9 +76,6 @@
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME         "MobiFlight RaspiPico"
 #endif
-#ifndef EEPROM_SIZE
-#define EEPROM_SIZE             4096    // EEPROMSizeRaspberryPico
-#endif
 #ifndef MEMLEN_CONFIG
 #define MEMLEN_CONFIG           1496    // MUST be less than EEPROM_SIZE!! MEM_OFFSET_CONFIG + MEM_LEN_CONFIG <= EEPROM_SIZE, see: eeprom_write_block (MEM_OFFSET_CONFIG, configBuffer, MEM_LEN_CONFIG);
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,7 +66,6 @@ board = megaatmega2560
 framework = arduino
 build_flags = 
 	${env.build_flags}
-	-DMF_CUSTOMDEVICE_SUPPORT=0
 	'-DMOBIFLIGHT_TYPE="MobiFlight Mega"'
 	-I./_Boards/Atmel/Board_Mega
 build_src_filter = 
@@ -85,7 +84,6 @@ board = sparkfun_promicro16
 framework = arduino
 build_flags = 
 	${env.build_flags}
-	-DMF_CUSTOMDEVICE_SUPPORT=0
 	'-DMOBIFLIGHT_TYPE="MobiFlight Micro"'
 	-I./_Boards/Atmel/Board_ProMicro
 build_src_filter = 
@@ -105,7 +103,6 @@ board = uno
 framework = arduino
 build_flags = 
 	${env.build_flags}
-	-DMF_CUSTOMDEVICE_SUPPORT=0
 	'-DMOBIFLIGHT_TYPE="MobiFlight Uno"'
 	-I./_Boards/Atmel/Board_Uno
 build_src_filter = 
@@ -124,7 +121,6 @@ board = nanoatmega328
 framework = arduino
 build_flags = 
 	${env.build_flags}
-	-DMF_CUSTOMDEVICE_SUPPORT=0
 	'-DMOBIFLIGHT_TYPE="MobiFlight Nano"'
 	-I./_Boards/Atmel/Board_Nano
 build_src_filter = 
@@ -148,7 +144,6 @@ upload_protocol = mbed									; for debugging upoading can be changed to picopr
 ;debug_tool = picoprobe									; and uncomment this for debugging w/ picoprobe
 build_flags =
 	${env.build_flags}
-	-DMF_CUSTOMDEVICE_SUPPORT=0
 	'-DMOBIFLIGHT_TYPE="MobiFlight RaspiPico"'
 	-I./_Boards/RaspberryPi/Pico
 build_src_filter =

--- a/src/MF_Modules/MFEEPROM.cpp
+++ b/src/MF_Modules/MFEEPROM.cpp
@@ -13,7 +13,7 @@ MFEEPROM::MFEEPROM() {}
 void MFEEPROM::init(void)
 {
 #if defined(ARDUINO_ARCH_RP2040)
-    EEPROM.begin(EEPROM_SIZE);
+    EEPROM.begin(4096);
 #endif
     _eepromLength = EEPROM.length();
 }


### PR DESCRIPTION
## Description of changes

Custom Devices are not a basic device, so `MF_CUSTOMDEVICE_SUPPORT` should be set to 0 or should be just not defined. So `#define MF_CUSTOMDEVICE_SUPPORT 1` / `#define MF_CUSTOMDEVICE_SUPPORT 2`  is deleted in all board.h files and in the platformio.ini file.

In the xyz_custom.ini files this definition is already included to get the custom devices compiled.

/edit: Fixes #263 
