### PR TITLE
bracket on wrong position

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -281,7 +281,7 @@ bool getArraysizes()
     if (!Output::setupArray(numberDevices[kTypeOutput]))
         sendFailureMessage("Output");
 #if MF_SEGMENT_SUPPORT == 1
-    if (!LedSegment::setupArray(numberDevices[kTypeLedSegmentDeprecated]) + numberDevices[kTypeLedSegmentMulti])
+    if (!LedSegment::setupArray(numberDevices[kTypeLedSegmentDeprecated] + numberDevices[kTypeLedSegmentMulti]))
         sendFailureMessage("7Segment");
 #endif
 #if MF_STEPPER_SUPPORT == 1


### PR DESCRIPTION
## Description of changes

With PR #253 the max numbers of devices with changed to a variable use of the device buffer.
Before the config gets loaded, it is checked if the devices will still fit into the device buffer.
For the 7 Segment device it is done like:
``if (!LedSegment::setupArray(numberDevices[kTypeLedSegmentDeprecated]) + numberDevices[kTypeLedSegmentMulti])
        sendFailureMessage("7Segment");
``
 But only the numbers of the old type `kTypeLedSegmentDeprecated` for the 7 segments are passed to the function `LedSegment::setupArray()` as one bracket is at the wrong position. Furthermore the `if` clause gets `true` and a status message gets generated. Unfortunately this status message gets not into the log of the connector (but this is another topic).

The fix is to move the first closing bracket to the end of the `if` clause to pass the number of old and new 7 segment devices to the function for setting up the array.

Fixes #266 