### PR TITLE
Beta - Fix memory overlap in DeviceBuffer

### DIFF
--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -15,9 +15,9 @@ std::size_t    deviceBuffer[MF_MAX_DEVICEMEM] = {0};
 uint16_t nextPointer                    = 0;
 
 #if defined (ARDUINO_ARCH_AVR)
-uint8_t     *allocateMemory(uint8_t size)
+uint8_t     *allocateMemory(uint16_t size)
 #else
-std::size_t    *allocateMemory(uint8_t size)
+std::size_t    *allocateMemory(uint16_t size)
 #endif
 {
     uint16_t actualPointer = nextPointer;
@@ -49,7 +49,7 @@ uint16_t GetAvailableMemory()
     return MF_MAX_DEVICEMEM - nextPointer;
 }
 
-bool FitInMemory(uint8_t size)
+bool FitInMemory(uint16_t size)
 {
     if (nextPointer + size > MF_MAX_DEVICEMEM)
         return false;

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -9,13 +9,13 @@
 #include <new>
 
 #if defined (ARDUINO_ARCH_AVR)
-uint8_t     *allocateMemory(uint8_t size);
+uint8_t     *allocateMemory(uint16_t size);
 #else
 std::size_t    *allocateMemory(uint8_t size);
 #endif
 
 void        ClearMemory();
 uint16_t    GetAvailableMemory();
-bool        FitInMemory(uint8_t size);
+bool        FitInMemory(uint16_t size);
 
 // allocatemem.h

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -11,7 +11,7 @@
 #if defined (ARDUINO_ARCH_AVR)
 uint8_t     *allocateMemory(uint16_t size);
 #else
-std::size_t    *allocateMemory(uint8_t size);
+std::size_t    *allocateMemory(uint16_t size);
 #endif
 
 void        ClearMemory();


### PR DESCRIPTION
## Description of changes

With PR #253 the limitation for the max devices per type was eliminated.
Before this PR memory was allocated in the device buffer for each single device. The highest amount of memory is 31 byte for one encoder.
Now the memory gets allocated in the device buffer for all devices of one type at once. If the required memory is more than 255 bytes, e.g. 9 encoders need 9 * 31bytes = 279 bytes, only 23 bytes gets reserved as the size to allocate memory is limited to a byte.

In `allocateMem.cpp/.h` the variable `size` within the functions `allocateMemory()` and `FitInMemory()` must be defined as `uint16_t`.

Fixes #271 
