### PR TITLE
Support keep alive messages from the desktop app

### DIFF
--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -104,7 +104,7 @@ void OnUnknownCommand()
     cmdMessenger.sendCmd(kStatus, F("n/a"));
 }
 
-// Handles requests from the desktop app to disable powersaving mode
+// Handles requests from the desktop app to disable power saving mode
 void OnSetPowerSavingMode()
 {
     bool enablePowerSavingMode = cmdMessenger.readBoolArg();
@@ -114,7 +114,7 @@ void OnSetPowerSavingMode()
     // power saving mode to get turned off.
     if (!enablePowerSavingMode) {
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kDebug, F("Disabling power save mode via request"));
+        cmdMessenger.sendCmd(kDebug, F("Disabling power saving mode via request"));
 #endif
         setLastCommandMillis();
     }

--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -109,27 +109,29 @@ void OnSetPowerSavingMode()
 {
     bool enablePowerSavingMode = cmdMessenger.readBoolArg();
 
+    // If the request is to enable powersaving mode then set the last command time
+    // to the earliest possible time. The next time loop() is called in mobiflight.cpp
+    // this will cause power saving mode to get turned on.
+    if (enablePowerSavingMode) {
+#ifdef DEBUG2CMDMESSENGER
+        cmdMessenger.sendCmd(kDebug, F("Enabling power saving mode via request"));
+#endif
+        lastCommand = 0;
+    }
     // If the request is to disable power saving mode then simply set the last command
     // to now. The next time loop() is called in mobiflight.cpp this will cause
     // power saving mode to get turned off.
-    if (!enablePowerSavingMode) {
+    else {
 #ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kDebug, F("Disabling power saving mode via request"));
 #endif
-        setLastCommandMillis();
+        lastCommand = millis();
     }
-
-    // There is no handling of a request to enable powersaving mode right now.
 }
 
 uint32_t getLastCommandMillis()
 {
     return lastCommand;
-}
-
-void setLastCommandMillis()
-{
-    lastCommand = millis();
 }
 
 void OnTrigger()

--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -77,6 +77,7 @@ void attachCommandCallbacks()
     cmdMessenger.attach(kSetName, OnSetName);
     cmdMessenger.attach(kGenNewSerial, OnGenNewSerial);
     cmdMessenger.attach(kTrigger, OnTrigger);
+    cmdMessenger.attach(kSetPowerSavingMode, OnSetPowerSavingMode);
 
 #if MF_LCD_SUPPORT == 1
     cmdMessenger.attach(kSetLcdDisplayI2C, LCDDisplay::OnSet);
@@ -100,6 +101,24 @@ void OnUnknownCommand()
 {
     lastCommand = millis();
     cmdMessenger.sendCmd(kStatus, F("n/a"));
+}
+
+// Handles requests from the desktop app to disable powersaving mode
+void OnSetPowerSavingMode()
+{
+    bool enablePowerSavingMode = cmdMessenger.readBoolArg();
+
+    // If the request is to disable power saving mode then simply set the last command
+    // to now. The next time loop() is called in mobiflight.cpp this will cause
+    // power saving mode to get turned off.
+    if (!enablePowerSavingMode) {
+#ifdef DEBUG2CMDMESSENGER
+        cmdMessenger.sendCmd(kDebug, F("Disabling power save mode"));
+#endif
+        setLastCommandMillis();
+    }
+
+    // There is no handling of a request to enable powersaving mode right now.
 }
 
 uint32_t getLastCommandMillis()

--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -114,7 +114,7 @@ void OnSetPowerSavingMode()
     // power saving mode to get turned off.
     if (!enablePowerSavingMode) {
 #ifdef DEBUG2CMDMESSENGER
-        cmdMessenger.sendCmd(kDebug, F("Disabling power save mode"));
+        cmdMessenger.sendCmd(kDebug, F("Disabling power save mode via request"));
 #endif
         setLastCommandMillis();
     }

--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -40,6 +40,7 @@
 CmdMessenger  cmdMessenger = CmdMessenger(Serial);
 unsigned long lastCommand;
 
+void OnSetPowerSavingMode();
 void OnTrigger();
 void OnUnknownCommand();
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -112,7 +112,6 @@ void OnSetConfig()
 #ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmd(kDebug, F("Setting config start"));
 #endif
-    setLastCommandMillis();
     char   *cfg    = cmdMessenger.readStringArg();
     uint8_t cfgLen = strlen(cfg);
 
@@ -533,7 +532,6 @@ void readConfig()
 
 void OnGetConfig()
 {
-    setLastCommandMillis();
     cmdMessenger.sendCmdStart(kInfo);
     if (configLength > 0) {
         cmdMessenger.sendCmdArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG));
@@ -551,7 +549,6 @@ void OnGetInfo()
     // OnGetInfo() is called from the connector and the time is very likely always different
     // Therefore millis() can be used for randomSeed
     generateSerial(false);
-    setLastCommandMillis();
     cmdMessenger.sendCmdStart(kInfo);
     cmdMessenger.sendCmdArg(F(MOBIFLIGHT_TYPE));
     cmdMessenger.sendCmdArg(name);

--- a/src/MF_Button/MFButton.cpp
+++ b/src/MF_Button/MFButton.cpp
@@ -3,17 +3,17 @@
 //
 // (C) MobiFlight Project 2022
 //
-
+#include "mobiflight.h"
 #include "MFButton.h"
 
 buttonEvent MFButton::_handler = NULL;
 
 MFButton::MFButton(uint8_t pin, const char *name)
 {
-    _pin   = pin;
-    _name  = name;
-    pinMode(_pin, INPUT_PULLUP);    // set pin to input
-    _state = digitalRead(_pin);     // initialize on actual status
+    _pin  = pin;
+    _name = name;
+    pinMode(_pin, INPUT_PULLUP); // set pin to input
+    _state = digitalRead(_pin);  // initialize on actual status
 }
 
 void MFButton::update()

--- a/src/MF_Button/MFButton.cpp
+++ b/src/MF_Button/MFButton.cpp
@@ -3,7 +3,6 @@
 //
 // (C) MobiFlight Project 2022
 //
-#include "mobiflight.h"
 #include "MFButton.h"
 
 buttonEvent MFButton::_handler = NULL;

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -16,7 +16,7 @@ namespace CustomDevice
     {
         if (!FitInMemory(sizeof(MFCustomDevice) * count))
             return false;
-        customDevice     = new (allocateMemory(sizeof(MFCustomDevice) * count)) MFCustomDevice(0,0,0);
+        customDevice     = new (allocateMemory(sizeof(MFCustomDevice) * count)) MFCustomDevice(0, 0, 0);
         maxCustomDevices = count;
         return true;
     }
@@ -80,9 +80,7 @@ namespace CustomDevice
         int16_t messageID = cmdMessenger.readInt16Arg();  // get the messageID number
         char   *output    = cmdMessenger.readStringArg(); // get the pointer to the new raw string
         cmdMessenger.unescape(output);                    // and unescape the string if escape characters are used
-        customDevice[device].set(messageID, output);     // send the string to your custom device
-
-        setLastCommandMillis();
+        customDevice[device].set(messageID, output);      // send the string to your custom device
     }
 
 } // end of namespace

--- a/src/MF_Encoder/MFEncoder.cpp
+++ b/src/MF_Encoder/MFEncoder.cpp
@@ -15,7 +15,7 @@
 // -----
 // 18.01.2014 created by Matthias Hertel
 // -----
-
+#include "mobiflight.h"
 #include "MFEncoder.h"
 
 // The array holds the values -1 for the entries where a position was decremented,
@@ -132,7 +132,7 @@ void MFEncoder::tick(void)
     int      _speed    = 0;
     uint32_t currentMs = millis();
 
-    int8_t   thisState = sig1 | (sig2 << 1);
+    int8_t thisState = sig1 | (sig2 << 1);
 
     if (currentMs - _lastFastDec > 100 && _detentCounter > 1) {
         _lastFastDec = currentMs;

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -70,14 +70,12 @@ namespace InputShifter
         for (uint8_t i = 0; i < inputShiftersRegistered; i++) {
             inputShifters[i].retrigger();
         }
-        setLastCommandMillis();
     }
 
     void OnInit() // not used anywhere!?
     {
         int module = cmdMessenger.readInt16Arg();
         inputShifters[module].clear();
-        setLastCommandMillis();
     }
 
 } // namespace

--- a/src/MF_LCDDisplay/LCDDisplay.cpp
+++ b/src/MF_LCDDisplay/LCDDisplay.cpp
@@ -52,7 +52,6 @@ namespace LCDDisplay
         char *output  = cmdMessenger.readStringArg();
         cmdMessenger.unescape(output);
         lcd_I2C[address].display(output);
-        setLastCommandMillis();
     }
 } // namespace
 

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -50,7 +50,6 @@ namespace Output
         // Set led
         analogWrite(pin, state); // why does the UI sends the pin number and not the x.th output number like other devices?
                                  //  output[pin].set(state);      // once this is changed uncomment this
-        setLastCommandMillis();
     }
 
     void PowerSave(bool state)

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -53,7 +53,6 @@ namespace OutputShifter
     {
         int module = cmdMessenger.readInt16Arg();
         outputShifters[module].clear();
-        setLastCommandMillis();
     }
 
     void OnSet()
@@ -63,7 +62,6 @@ namespace OutputShifter
         char *pins   = cmdMessenger.readStringArg();
         int   value  = cmdMessenger.readInt16Arg();
         outputShifters[module].setPins(pins, value);
-        setLastCommandMillis();
     }
 } // namespace
 

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -59,7 +59,6 @@ namespace LedSegment
         int subModule  = cmdMessenger.readInt16Arg();
         int brightness = cmdMessenger.readInt16Arg();
         ledSegments[module].setBrightness(subModule, brightness);
-        setLastCommandMillis();
     }
 
     void OnSetModule()
@@ -70,7 +69,6 @@ namespace LedSegment
         uint8_t points    = (uint8_t)cmdMessenger.readInt16Arg();
         uint8_t mask      = (uint8_t)cmdMessenger.readInt16Arg();
         ledSegments[module].display(subModule, value, points, mask);
-        setLastCommandMillis();
     }
 
     void OnSetModuleBrightness()
@@ -79,7 +77,6 @@ namespace LedSegment
         int subModule  = cmdMessenger.readInt16Arg();
         int brightness = cmdMessenger.readInt16Arg();
         ledSegments[module].setBrightness(subModule, brightness);
-        setLastCommandMillis();
     }
 } // namespace
 

--- a/src/MF_Servo/Servos.cpp
+++ b/src/MF_Servo/Servos.cpp
@@ -53,7 +53,6 @@ namespace Servos
         if (servo >= servosRegistered)
             return;
         servos[servo].moveTo(newValue);
-        setLastCommandMillis();
     }
 
     void update()

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -62,7 +62,6 @@ namespace Stepper
         if (stepper >= steppersRegistered)
             return;
         steppers[stepper].moveTo(newPos);
-        setLastCommandMillis();
     }
 
     void OnReset()
@@ -72,7 +71,6 @@ namespace Stepper
         if (stepper >= steppersRegistered)
             return;
         steppers[stepper].reset();
-        setLastCommandMillis();
     }
 
     void OnSetZero()
@@ -82,7 +80,6 @@ namespace Stepper
         if (stepper >= steppersRegistered)
             return;
         steppers[stepper].setZero();
-        setLastCommandMillis();
     }
 
     void OnSetSpeedAccel()

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -123,9 +123,9 @@ void SetPowerSavingMode(bool state)
 
 #ifdef DEBUG2CMDMESSENGER
     if (state)
-        cmdMessenger.sendCmd(kDebug, F("On"));
+        cmdMessenger.sendCmd(kDebug, F("Power saving mode on"));
     else
-        cmdMessenger.sendCmd(kDebug, F("Off"));
+        cmdMessenger.sendCmd(kDebug, F("Power saving mode off"));
 #endif
 }
 

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -145,7 +145,6 @@ void updatePowerSaving()
 // ************************************************************
 void ResetBoard()
 {
-    setLastCommandMillis();
     restoreName();
     loadConfig();
 }


### PR DESCRIPTION
Fixes #273

This PR fundamentally changes how the firmware knows when to keep displays awake.

Instead of relying on the firmware to track when various events happen (and missing some events, like buttons, encoders, and multiplexers), it simply relies on the desktop app to tell it to stay awake.

The companion desktop app change sends a keep alive message every 5 minutes. If it's been 15 minutes since one of those messages came in the firmware will put displays to sleep.

Bonus: Removing all the calls to `setLastCommandMillis` saves about 1k of space (at least for the pico)