### PR TITLE
Beta - Board wont crash if limit switch for steppers is configured

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -387,7 +387,7 @@ void readConfig()
             params[6] = (uint8_t)0; // backlash
             params[7] = false;      // deactivate output
 
-            if (command == kTypeStepperDeprecated2) {
+            if (command == kTypeStepperDeprecated2 || command == kTypeStepper) {
                 params[4] = readUintFromEEPROM(&addreeprom); // Button number
             }
 

--- a/src/MF_Stepper/MFStepper.cpp
+++ b/src/MF_Stepper/MFStepper.cpp
@@ -82,6 +82,9 @@ void MFStepper::detach()
 
 void MFStepper::moveTo(long newPosition)
 {
+    if (!_initialized)
+        return;
+
     _resetting           = false;
     long currentPosition = _stepper->currentPosition();
 
@@ -100,13 +103,11 @@ void MFStepper::moveTo(long newPosition)
     }
 }
 
-uint8_t MFStepper::getZeroPin()
-{
-    return _zeroPin;
-}
-
 void MFStepper::setZero()
 {
+    if (!_initialized)
+        return;
+
     _stepper->setCurrentPosition(0);
     if (_inMove == MOVE_CW) {
         _stepper->moveTo(-_backlash);
@@ -115,6 +116,9 @@ void MFStepper::setZero()
 
 void MFStepper::setZeroInReset()
 {
+    if (!_initialized)
+        return;
+
     if (_resetting) {
         _stepper->setCurrentPosition(0);
         _resetting = false;
@@ -123,6 +127,9 @@ void MFStepper::setZeroInReset()
 
 void MFStepper::checkZeroPin()
 {
+    if (!_initialized)
+        return;
+
     uint8_t newState = (uint8_t)digitalRead(_zeroPin);
     if (newState != _zeroPinState) {
         _zeroPinState = newState;
@@ -132,6 +139,9 @@ void MFStepper::checkZeroPin()
 
 void MFStepper::update()
 {
+    if (!_initialized)
+        return;
+
     _stepper->run();
     checkZeroPin();
     if (_stepper->currentPosition() == (_targetPos + _backlash * _inMove) && _deactivateOutput) {
@@ -142,6 +152,9 @@ void MFStepper::update()
 
 void MFStepper::reset()
 {
+    if (!_initialized)
+        return;
+
     // we are not a auto reset stepper if this pin is 0
     if (_zeroPin == 0)
         return;
@@ -159,16 +172,24 @@ void MFStepper::reset()
 
 void MFStepper::setMaxSpeed(uint16_t speed)
 {
+    if (!_initialized)
+        return;
+
     _stepper->setMaxSpeed(speed);
 }
 
 void MFStepper::setAcceleration(uint16_t acceleration)
 {
+    if (!_initialized)
+        return;
+
     _stepper->setAcceleration(acceleration);
 }
 
 void MFStepper::powerSavingMode(bool state)
 {
+    if (!_initialized)
+        return;
     if (state)
         _stepper->disableOutputs();
     else

--- a/src/MF_Stepper/MFStepper.h
+++ b/src/MF_Stepper/MFStepper.h
@@ -24,7 +24,6 @@ public:
     void    setMaxSpeed(uint16_t speed);
     void    setAcceleration(uint16_t acceleration);
     void    setZero();
-    uint8_t getZeroPin();
     void    powerSavingMode(bool state);
 
 private:


### PR DESCRIPTION
## Description of changes

With the code changes done with PR #261 the structure for reading the stepper config was bundled and slightly changed.
While the config gets read from the eeprom, the parameter are assigned to an array and this array is used for the parameters of the `Stepper::Add(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]);` function.
For the actual stepper type the button gets not read which is now added with this PR. Furthermore sending commands to an not initialized stepper will be blocked

If the button gets not read, the next read command, which is reading the stepper mode, reads the button number. So the button number is treated as stepper mode. Within the stepper code it's checked if it's a valid mode. If not, and that's for all button numbers bigger then 2, creating a new stepper class is aborted. This is saved but not considered when commands are issued. 

Fixes #275 