### PR TITLE
Renaming of KAV's environment w/o display names

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@
 [platformio]
 ; include custom environments to be build
 extra_configs =
-	./CustomDevices/KAV_Simulation/EFIS_FCU/EFIS_FCU_platformio.ini
+	./CustomDevices/KAV_Simulation/displays_platformio.ini
 	./CustomDevices/Mobiflight/GNC255/GNC255_platformio.ini
 	./CustomDevices/Mobiflight/TM1637/TM1637_platformio.ini
 	./CustomDevices/Mobiflight/GenericI2C/GenericI2C_platformio.ini


### PR DESCRIPTION
## Description of changes

Renamed the build environment for KAV's displays without the display types in the filename.
Additionally the file path is adjusted according the changes in the custom device repo.