### PR TITLE
Set PR build versions to `0.pr.prbuild`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run PlatformIO
         env:
-          VERSION: "0.0.${{ github.event.number }}"
+          VERSION: "0.${{ github.event.pull_request.number }}.${{ github.event.number }}"
         run: pio run
 
       - name: Archive production artifacts


### PR DESCRIPTION
Fixes #279

## Description of changes

Uses the `${{ github.event.pull_request.number }}` environment variable to get the pull request number for the build version.