### PR TITLE
MOBIFLIGHT_TYPE is already defined in MFBoards.h

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -66,7 +66,6 @@ board = megaatmega2560
 framework = arduino
 build_flags = 
 	${env.build_flags}
-	'-DMOBIFLIGHT_TYPE="MobiFlight Mega"'
 	-I./_Boards/Atmel/Board_Mega
 build_src_filter = 
 	${env.build_src_filter}
@@ -84,7 +83,6 @@ board = sparkfun_promicro16
 framework = arduino
 build_flags = 
 	${env.build_flags}
-	'-DMOBIFLIGHT_TYPE="MobiFlight Micro"'
 	-I./_Boards/Atmel/Board_ProMicro
 build_src_filter = 
 	${env.build_src_filter}
@@ -103,7 +101,6 @@ board = uno
 framework = arduino
 build_flags = 
 	${env.build_flags}
-	'-DMOBIFLIGHT_TYPE="MobiFlight Uno"'
 	-I./_Boards/Atmel/Board_Uno
 build_src_filter = 
 	${env.build_src_filter}
@@ -121,7 +118,6 @@ board = nanoatmega328
 framework = arduino
 build_flags = 
 	${env.build_flags}
-	'-DMOBIFLIGHT_TYPE="MobiFlight Nano"'
 	-I./_Boards/Atmel/Board_Nano
 build_src_filter = 
 	${env.build_src_filter}
@@ -144,7 +140,6 @@ upload_protocol = mbed									; for debugging upoading can be changed to picopr
 ;debug_tool = picoprobe									; and uncomment this for debugging w/ picoprobe
 build_flags =
 	${env.build_flags}
-	'-DMOBIFLIGHT_TYPE="MobiFlight RaspiPico"'
 	-I./_Boards/RaspberryPi/Pico
 build_src_filter =
 	${env.build_src_filter}


### PR DESCRIPTION
## Description of changes

With PR #258 custom devices were added. Accidently `'-DMOBIFLIGHT_TYPE="MobiFlight Micro"'` was added to the `platformio.ini` file, but as it is a standard definition it belongs to MFBoards.h``where it is still part of this file. So no need to do it in `platformio.ini`.

For custom devices this definition is still required to have it in the custom ini file to override the standard type.

