### PR TITLE
Two pins get set on Pico Board

### DIFF
--- a/src/MF_Output/MFOutput.cpp
+++ b/src/MF_Output/MFOutput.cpp
@@ -6,14 +6,18 @@
 
 #include "MFOutput.h"
 
-MFOutput::MFOutput() {}
+MFOutput::MFOutput()
+{
+    _value = false;
+}
 
-void MFOutput::init(uint8_t pin)
+void MFOutput::attach(uint8_t pin)
 {
     _pin   = pin;
-    _value = false;
+#if !defined(ARDUINO_ARCH_RP2040)
     pinMode(_pin, OUTPUT);
     set(_value);
+#endif
 }
 
 void MFOutput::set(uint8_t value)

--- a/src/MF_Output/MFOutput.cpp
+++ b/src/MF_Output/MFOutput.cpp
@@ -6,11 +6,13 @@
 
 #include "MFOutput.h"
 
-MFOutput::MFOutput(uint8_t pin)
+MFOutput::MFOutput() {}
+
+void MFOutput::init(uint8_t pin)
 {
     _pin   = pin;
     _value = false;
-    pinMode(_pin, OUTPUT); // set pin to input
+    pinMode(_pin, OUTPUT);
     set(_value);
 }
 

--- a/src/MF_Output/MFOutput.h
+++ b/src/MF_Output/MFOutput.h
@@ -12,7 +12,7 @@ class MFOutput
 {
 public:
     MFOutput();
-    void init(uint8_t pin = 1);
+    void attach(uint8_t pin);
     void set(uint8_t value);
     void powerSavingMode(bool state);
 

--- a/src/MF_Output/MFOutput.h
+++ b/src/MF_Output/MFOutput.h
@@ -11,7 +11,8 @@
 class MFOutput
 {
 public:
-    MFOutput(uint8_t pin = 1);
+    MFOutput();
+    void init(uint8_t pin = 1);
     void set(uint8_t value);
     void powerSavingMode(bool state);
 

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -28,9 +28,10 @@ namespace Output
         if (outputsRegistered == maxOutputs)
             return;
         outputs[outputsRegistered] = MFOutput();
-        outputs[outputsRegistered].init(pin);
+        outputs[outputsRegistered].attach(pin);
 #if defined(ARDUINO_ARCH_RP2040)
         pinMode(pin, OUTPUT);
+        analogWrite(pin, false);
 #endif
         outputsRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -30,7 +30,7 @@ namespace Output
         outputs[outputsRegistered] = MFOutput();
         outputs[outputsRegistered].attach(pin);
 #if defined(ARDUINO_ARCH_RP2040)
-        pinMode(pin, OUTPUT);
+        pinMode(pin, OUTPUT_12MA);
         analogWrite(pin, false);
 #endif
         outputsRegistered++;

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -27,7 +27,11 @@ namespace Output
     {
         if (outputsRegistered == maxOutputs)
             return;
-        outputs[outputsRegistered] = MFOutput(pin);
+        outputs[outputsRegistered] = MFOutput();
+        outputs[outputsRegistered].init(pin);
+#if defined(ARDUINO_ARCH_RP2040)
+        pinMode(pin, OUTPUT);
+#endif
         outputsRegistered++;
 #ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kDebug, F("Added output"));


### PR DESCRIPTION
## Description of changes

On the Pico two pins get set at the same time if both pins are configured as output and the difference of the pin numbers are 16.

Moving the initialization of the pin from the class `MFOutput()` to the function which calls the initialization `Output::Add()` solves this issue.
For now it is unclear why this change fixes it. More investigation has to be done.
The change is only done for the Pico and not for the other boards.

Additionally changes are implemented to fix issue #284 to avoid merge errors when both PR gets merged. An additional comment will be given in the upcoming PR.

Fixes #283 