### PR TITLE
init devices with attach() function and not via constructor

### DIFF
--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -37,7 +37,8 @@ namespace Analog
         if (analogRegistered == maxAnalogIn)
             return;
 
-        analog[analogRegistered] = MFAnalog(pin, name, sensitivity);
+        analog[analogRegistered] = MFAnalog();
+        analog[analogRegistered].attach(pin, name, sensitivity);
         MFAnalog::attachHandler(handlerOnAnalogChange);
         analogRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -31,7 +31,7 @@ void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity)
 bool MFAnalog::valueHasChanged(int16_t newValue)
 {
     if (!_initialized)
-        return;
+        return false;
     return (abs(newValue - _lastValue) >= _sensitivity);
 }
 

--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -8,7 +8,12 @@
 
 analogEvent MFAnalog::_handler = NULL;
 
-MFAnalog::MFAnalog(uint8_t pin, const char *name, uint8_t sensitivity)
+MFAnalog::MFAnalog()
+{
+    _initialized = false;
+}
+
+void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity)
 {
     _sensitivity = sensitivity;
     _pin         = pin;
@@ -20,15 +25,20 @@ MFAnalog::MFAnalog(uint8_t pin, const char *name, uint8_t sensitivity)
     }
     // and set initial value from buffers
     _lastValue = ADC_Average_Total >> ADC_MAX_AVERAGE_LOG2;
+    _initialized = true;
 }
 
 bool MFAnalog::valueHasChanged(int16_t newValue)
 {
+    if (!_initialized)
+        return;
     return (abs(newValue - _lastValue) >= _sensitivity);
 }
 
 void MFAnalog::readChannel(uint8_t alwaysTrigger)
 {
+    if (!_initialized)
+        return;
     int16_t newValue = ADC_Average_Total >> ADC_MAX_AVERAGE_LOG2;
     if (alwaysTrigger || valueHasChanged(newValue)) {
         _lastValue = newValue;
@@ -49,7 +59,9 @@ void MFAnalog::retrigger()
 }
 
 void MFAnalog::readBuffer()
-{                                                           // read ADC and calculate floating average, call it every ~10ms
+{                          
+    if (!_initialized)
+        return;                                 // read ADC and calculate floating average, call it every ~10ms
     ADC_Average_Total -= ADC_Buffer[(ADC_Average_Pointer)]; // subtract oldest value to save the newest value
     ADC_Buffer[ADC_Average_Pointer] = analogRead(_pin);     // store read in, must be subtracted in next loop
     ADC_Average_Total += ADC_Buffer[ADC_Average_Pointer];   // add read in for floating average

--- a/src/MF_Analog/MFAnalog.h
+++ b/src/MF_Analog/MFAnalog.h
@@ -24,8 +24,9 @@ typedef void (*analogEvent)(int, const char *);
 class MFAnalog
 {
 public:
-    MFAnalog(uint8_t pin = 1, const char *name = "Analog Input", uint8_t sensitivity = 2);
+    MFAnalog();
     static void attachHandler(analogEvent handler);
+    void        attach(uint8_t pin, const char *name, uint8_t sensitivity);
     void        update();
     void        retrigger();
     void        readBuffer();
@@ -41,6 +42,7 @@ private:
     uint16_t         ADC_Average_Total           = 0;   // sum of sampled values, must be divided by ADC_MAX_AVERAGE to get actual value
     volatile uint8_t ADC_Average_Pointer         = 0;   // points to the actual position in ADC_BUFFER
     uint32_t         _lastReadBuffer;
+    bool             _initialized;
 
     void readChannel(uint8_t compare);
     bool valueHasChanged(int16_t newValue);

--- a/src/MF_Button/Button.cpp
+++ b/src/MF_Button/Button.cpp
@@ -35,7 +35,8 @@ namespace Button
     {
         if (buttonsRegistered == maxButtons)
             return;
-        buttons[buttonsRegistered] = MFButton(pin, name);
+        buttons[buttonsRegistered] = MFButton();
+        buttons[buttonsRegistered].attach(pin, name);
         MFButton::attachHandler(handlerOnButton);
         buttonsRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_Button/MFButton.cpp
+++ b/src/MF_Button/MFButton.cpp
@@ -7,16 +7,24 @@
 
 buttonEvent MFButton::_handler = NULL;
 
-MFButton::MFButton(uint8_t pin, const char *name)
+MFButton::MFButton()
+{
+    _initialized = false;
+}
+
+void MFButton::attach(uint8_t pin, const char *name)
 {
     _pin  = pin;
     _name = name;
     pinMode(_pin, INPUT_PULLUP); // set pin to input
     _state = digitalRead(_pin);  // initialize on actual status
+    _initialized = true;
 }
 
 void MFButton::update()
 {
+    if (!_initialized)
+        return;
     uint8_t newState = (uint8_t)digitalRead(_pin);
     if (newState != _state) {
         _state = newState;
@@ -31,6 +39,8 @@ void MFButton::trigger(uint8_t state)
 
 void MFButton::triggerOnPress()
 {
+    if (!_initialized)
+        return;
     if (_handler && _state == LOW) {
         (*_handler)(btnOnPress, _name);
     }
@@ -38,6 +48,8 @@ void MFButton::triggerOnPress()
 
 void MFButton::triggerOnRelease()
 {
+    if (!_initialized)
+        return;
     if (_handler && _state == HIGH) {
         (*_handler)(btnOnRelease, _name);
     }

--- a/src/MF_Button/MFButton.h
+++ b/src/MF_Button/MFButton.h
@@ -23,8 +23,9 @@ enum {
 class MFButton
 {
 public:
-    MFButton(uint8_t pin = 1, const char *name = "Button");
+    MFButton();
     static void attachHandler(buttonEvent newHandler);
+    void        attach(uint8_t pin, const char *name);
     void        update();
     void        trigger(uint8_t state);
     void        triggerOnPress();
@@ -35,6 +36,7 @@ public:
 private:
     static buttonEvent _handler;
     bool               _state;
+    bool               _initialized;
 };
 
 // MFButton.h

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -16,7 +16,7 @@ namespace CustomDevice
     {
         if (!FitInMemory(sizeof(MFCustomDevice) * count))
             return false;
-        customDevice     = new (allocateMemory(sizeof(MFCustomDevice) * count)) MFCustomDevice(0, 0, 0);
+        customDevice     = new (allocateMemory(sizeof(MFCustomDevice) * count)) MFCustomDevice();
         maxCustomDevices = count;
         return true;
     }
@@ -25,7 +25,8 @@ namespace CustomDevice
     {
         if (customDeviceRegistered == maxCustomDevices)
             return;
-        customDevice[customDeviceRegistered] = MFCustomDevice(adrPin, adrType, adrConfig);
+        customDevice[customDeviceRegistered] = MFCustomDevice();
+        customDevice[customDeviceRegistered].attach(adrPin, adrType, adrConfig);
         customDeviceRegistered++;
 #ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kStatus, F("Added CustomDevice"));

--- a/src/MF_InputShifter/MFInputShifter.cpp
+++ b/src/MF_InputShifter/MFInputShifter.cpp
@@ -8,10 +8,9 @@
 
 inputShifterEvent MFInputShifter::_inputHandler = NULL;
 
-MFInputShifter::MFInputShifter(const char *name)
+MFInputShifter::MFInputShifter()
 {
     _initialized = false;
-    _name        = name;
 }
 
 // Registers a new input shifter and configures the clock, data and latch pins as well

--- a/src/MF_InputShifter/MFInputShifter.h
+++ b/src/MF_InputShifter/MFInputShifter.h
@@ -25,7 +25,7 @@ enum {
 class MFInputShifter
 {
 public:
-    MFInputShifter(const char *name = "InputShifter");
+    MFInputShifter();
     void        attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount, const char *name);
     static void attachHandler(inputShifterEvent newHandler);
     void        clear();

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -28,7 +28,7 @@ namespace LedSegment
         if (ledSegmentsRegistered == ledSegmentsRegistereds)
             return;
         ledSegments[ledSegmentsRegistered] = MFSegments();
-        ledSegments[ledSegmentsRegistered].attach(type, dataPin, csPin, clkPin, numDevices, brightness); // lc is our object
+        ledSegments[ledSegmentsRegistered].attach(type, dataPin, csPin, clkPin, numDevices, brightness);
         ledSegmentsRegistered++;
 #ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kDebug, F("Added Led Segment"));

--- a/src/MF_Servo/MFServo.cpp
+++ b/src/MF_Servo/MFServo.cpp
@@ -60,12 +60,6 @@ void MFServo::attach(uint8_t pin, bool enable)
 MFServo::MFServo()
     : _servo() {}
 
-MFServo::MFServo(uint8_t pin, bool enable)
-    : _servo()
-{
-    attach(pin, enable);
-}
-
 void MFServo::setExternalRange(int min, int max)
 {
     _mapRange[0] = min;

--- a/src/MF_Servo/MFServo.h
+++ b/src/MF_Servo/MFServo.h
@@ -13,8 +13,7 @@ class MFServo
 {
 public:
     MFServo();
-    MFServo(uint8_t pin, bool enable = true);
-    void attach(uint8_t pin = 1, bool enable = true);
+    void attach(uint8_t pin, bool enable);
     void detach();
     void setExternalRange(int min, int max);
     void setInternalRange(int min, int max);

--- a/src/MF_Stepper/MFStepper.h
+++ b/src/MF_Stepper/MFStepper.h
@@ -16,7 +16,7 @@ class MFStepper
 
 public:
     MFStepper();
-    void    attach(uint8_t pin1 = 1, uint8_t pin2 = 2, uint8_t pin3 = 3, uint8_t pin4 = 4, uint8_t btnPin1 = 0, uint8_t mode = 0, int8_t backlash = 0, bool deactivateOutput = false);
+    void    attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, uint8_t btnPin1, uint8_t mode, int8_t backlash, bool deactivateOutput);
     void    detach();
     void    update();
     void    reset();


### PR DESCRIPTION
## Description of changes

For the devices `AnalogIn` and `Buttons` an `attach()` function ia added where all required init paramaters are transferred. These init parameters were part of the constructor.
Now calling the constructor will only set that the device is not initialized.

The calling of the constructor is since PR #253 also done to calculate the required memory for all devices of one type and to reserve it.  As no init parameters are available at this point the standard paramaters were taken and e.g. pin 1 for the output and analogIn device was set output / input.

The required changes for outputs are part of PR #285.

For the InputShifter the default value in the constructor is deleted. Not required here as it gets set also in the attach() function.

For the servo device the not required constructor was deleted.

For the stepper the default parameters in the attach() function are deleted to be the same as the other devices.

Fixes #284 