### PR TITLE
Double set pin

### DIFF
--- a/src/MF_Output/MFOutput.cpp
+++ b/src/MF_Output/MFOutput.cpp
@@ -16,26 +16,21 @@ void MFOutput::attach(uint8_t pin)
     _pin   = pin;
 #if defined(ARDUINO_ARCH_RP2040)
     pinMode(_pin, OUTPUT_12MA);
-    digitalWrite(_pin, LOW);
 #else
     pinMode(_pin, OUTPUT);
-    analogWrite(pin, LOW);
 #endif
+    set(LOW);
 }
 
 void MFOutput::set(uint8_t value)
 {
     _value = value;
-#if defined(ARDUINO_ARCH_RP2040)
     if (_value == 0xFF)
         digitalWrite(_pin, HIGH);
     else if (_value == 0x00)
         digitalWrite(_pin, LOW);
     else
         analogWrite(_pin, _value);
-#else
-    analogWrite(_pin, _value);
-#endif
 }
 
 void MFOutput::powerSavingMode(bool state)

--- a/src/MF_Output/MFOutput.cpp
+++ b/src/MF_Output/MFOutput.cpp
@@ -16,21 +16,26 @@ void MFOutput::attach(uint8_t pin)
     _pin   = pin;
 #if defined(ARDUINO_ARCH_RP2040)
     pinMode(_pin, OUTPUT_12MA);
+    digitalWrite(_pin, LOW)
 #else
     pinMode(_pin, OUTPUT);
+    analogWrite(pin, LOW);
 #endif
-    digitalWrite(pin,0);
 }
 
 void MFOutput::set(uint8_t value)
 {
     _value = value;
+#if defined(ARDUINO_ARCH_RP2040)
     if (_value == 0xFF)
         digitalWrite(_pin, HIGH);
     else if (_value == 0x00)
         digitalWrite(_pin, LOW);
     else
         analogWrite(_pin, _value);
+#else
+    analogWrite(_pin, _value);
+#endif
 }
 
 void MFOutput::powerSavingMode(bool state)

--- a/src/MF_Output/MFOutput.cpp
+++ b/src/MF_Output/MFOutput.cpp
@@ -14,16 +14,23 @@ MFOutput::MFOutput()
 void MFOutput::attach(uint8_t pin)
 {
     _pin   = pin;
-#if !defined(ARDUINO_ARCH_RP2040)
+#if defined(ARDUINO_ARCH_RP2040)
+    pinMode(_pin, OUTPUT_12MA);
+#else
     pinMode(_pin, OUTPUT);
-    set(_value);
 #endif
+    digitalWrite(pin,0);
 }
 
 void MFOutput::set(uint8_t value)
 {
     _value = value;
-    analogWrite(_pin, _value);
+    if (_value == 0xFF)
+        digitalWrite(_pin, HIGH);
+    else if (_value == 0x00)
+        digitalWrite(_pin, LOW);
+    else
+        analogWrite(_pin, _value);
 }
 
 void MFOutput::powerSavingMode(bool state)

--- a/src/MF_Output/MFOutput.cpp
+++ b/src/MF_Output/MFOutput.cpp
@@ -16,7 +16,7 @@ void MFOutput::attach(uint8_t pin)
     _pin   = pin;
 #if defined(ARDUINO_ARCH_RP2040)
     pinMode(_pin, OUTPUT_12MA);
-    digitalWrite(_pin, LOW)
+    digitalWrite(_pin, LOW);
 #else
     pinMode(_pin, OUTPUT);
     analogWrite(pin, LOW);

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -50,14 +50,18 @@ namespace Output
         int state = cmdMessenger.readInt16Arg();
     
         // Set led
+#if defined(ARDUINO_ARCH_RP2040)
         if (state == 0xFF)
             digitalWrite(pin, HIGH);
         else if (state == 0x00)
             digitalWrite(pin, LOW);
         else
-            analogWrite(pin, state);    // why does the UI sends the pin number and not the x.th output number like other devices?
-        // output[pin].set(state);      // once this is changed uncomment this
-
+            analogWrite(pin, state);        // why does the UI sends the pin number and not the x.th output number like other devices?
+            // output[pin].set(state);      // once this is changed uncomment this
+#else
+        analogWrite(pin, state);            // why does the UI sends the pin number and not the x.th output number like other devices?
+        // output[pin].set(state);          // once this is changed uncomment this
+#endif
     }
     void PowerSave(bool state)
     {

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -50,19 +50,14 @@ namespace Output
         int state = cmdMessenger.readInt16Arg();
     
         // Set led
-#if defined(ARDUINO_ARCH_RP2040)
         if (state == 0xFF)
             digitalWrite(pin, HIGH);
         else if (state == 0x00)
             digitalWrite(pin, LOW);
         else
-            analogWrite(pin, state);        // why does the UI sends the pin number and not the x.th output number like other devices?
-            // output[pin].set(state);      // once this is changed uncomment this
-#else
-        analogWrite(pin, state);            // why does the UI sends the pin number and not the x.th output number like other devices?
-        // output[pin].set(state);          // once this is changed uncomment this
-#endif
+            analogWrite(pin, state);
     }
+
     void PowerSave(bool state)
     {
         for (uint8_t i = 0; i < outputsRegistered; ++i) {

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -29,10 +29,6 @@ namespace Output
             return;
         outputs[outputsRegistered] = MFOutput();
         outputs[outputsRegistered].attach(pin);
-#if defined(ARDUINO_ARCH_RP2040)
-        pinMode(pin, OUTPUT_12MA);
-        analogWrite(pin, false);
-#endif
         outputsRegistered++;
 #ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kDebug, F("Added output"));
@@ -52,11 +48,17 @@ namespace Output
         // Read led state argument, interpret string as boolean
         int pin   = cmdMessenger.readInt16Arg();
         int state = cmdMessenger.readInt16Arg();
+    
         // Set led
-        analogWrite(pin, state); // why does the UI sends the pin number and not the x.th output number like other devices?
-                                 //  output[pin].set(state);      // once this is changed uncomment this
-    }
+        if (state == 0xFF)
+            digitalWrite(pin, HIGH);
+        else if (state == 0x00)
+            digitalWrite(pin, LOW);
+        else
+            analogWrite(pin, state);    // why does the UI sends the pin number and not the x.th output number like other devices?
+        // output[pin].set(state);      // once this is changed uncomment this
 
+    }
     void PowerSave(bool state)
     {
         for (uint8_t i = 0; i < outputsRegistered; ++i) {


### PR DESCRIPTION
## Description of changes

Further evaluation of issue #283 showed that PR #285 didn't solve the issue.
Pico is limited to one bank of 16 PWM timer starting at Pin 0. If using a pin > 15 also as PWM output, these pins get doubled.
E.g. using pin 2 as PWM output and unsing pin 18 as PWM output each change on pin 2 or pin 18 will also set the other one.
If one of these pins are used as a digital output everything is fine.

Within the code for the outputs `analogWrite()` is always used toset an output. Doing it this way each pin is used as PWM output for the Pico and the above problem occurs. The only way to solve it is to use only the first 16 pins as PWM output. This change will be done in a separate PR to adapt the `raspberrypi_pico.board.json` by setting `"isPWM": false` for pins > 15. So for pins > 15 the value for setting the pin will either be `0` or `255`.
Within the FW it has to check if the value for each pin is `0` or `255`. In this case `digitalWrite()` is used instead of `analogWrite()` which avoids setting the output as PWM.
This change is only done for the Pico, for AVR's it is kept as it is to not raise another potential problem (which I can not see, just to be absolutely sure).

Fixes #283 
