### PR TITLE
Added beta-bug label for release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,15 +14,16 @@ changelog:
     - title: Bug Fixes 🐛
       labels:
         - bug
-    - title: Bug Fixes (BETA) 🐛
-      labels:
-        - bug_beta
     - title: Documentation 📚
       labels:
         - documentation
     - title: Development 💻
       labels:
         - development    
+    - title: Bug Fixes (BETA) 🐛
+      labels:
+        - bug_beta
+        - beta-bug
     - title: Other Changes ⚡
       labels:
         - "*"


### PR DESCRIPTION
## Description of changes
We are using beta-bugs as label in this repository but it was not part of the release.yml

fixes #269 

- [x] add beta-bugs to the supported labels
- [x] change order, beta bugs is less important
