### PR TITLE
No fixed max. shifters per chain

### DIFF
--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -39,7 +39,7 @@ namespace InputShifter
         inputShifters[inputShiftersRegistered] = MFInputShifter();
         if (!inputShifters[inputShiftersRegistered].attach(latchPin, clockPin, dataPin, modules, name))
         {
-            cmdMessenger.sendCmd(kStatus, F("InputShifter array does not fit in Memory"));
+            cmdMessenger.sendCmd(kStatus, F("InputShifter array does not fit into Memory"));
             return;
         }
         MFInputShifter::attachHandler(handlerInputShifterOnChange);

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -12,7 +12,7 @@ namespace InputShifter
 {
     MFInputShifter *inputShifters;
     uint8_t         inputShiftersRegistered = 0;
-    uint8_t         maxInputShiffter        = 0;
+    uint8_t         maxInputShifter        = 0;
 
     void handlerInputShifterOnChange(uint8_t eventId, uint8_t pin, const char *name)
     {
@@ -28,16 +28,20 @@ namespace InputShifter
         if (!FitInMemory(sizeof(MFInputShifter) * count))
             return false;
         inputShifters    = new (allocateMemory(sizeof(MFInputShifter) * count)) MFInputShifter;
-        maxInputShiffter = count;
+        maxInputShifter = count;
         return true;
     }
 
     void Add(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t modules, char const *name)
     {
-        if (inputShiftersRegistered == maxInputShiffter)
+        if (inputShiftersRegistered == maxInputShifter)
             return;
         inputShifters[inputShiftersRegistered] = MFInputShifter();
-        inputShifters[inputShiftersRegistered].attach(latchPin, clockPin, dataPin, modules, name);
+        if (!inputShifters[inputShiftersRegistered].attach(latchPin, clockPin, dataPin, modules, name))
+        {
+            cmdMessenger.sendCmd(kStatus, F("InputShifter array does not fit in Memory"));
+            return;
+        }
         MFInputShifter::attachHandler(handlerInputShifterOnChange);
         inputShiftersRegistered++;
 #ifdef DEBUG2CMDMESSENGER
@@ -70,12 +74,6 @@ namespace InputShifter
         for (uint8_t i = 0; i < inputShiftersRegistered; i++) {
             inputShifters[i].retrigger();
         }
-    }
-
-    void OnInit() // not used anywhere!?
-    {
-        int module = cmdMessenger.readInt16Arg();
-        inputShifters[module].clear();
     }
 
 } // namespace

--- a/src/MF_InputShifter/InputShifter.h
+++ b/src/MF_InputShifter/InputShifter.h
@@ -12,7 +12,6 @@ namespace InputShifter
     bool setupArray(uint16_t count);
     void Add(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t modules, char const *name = "InputShifter");
     void Clear();
-    // void OnInit();        // this is defined but not used!?
     void read();
     void OnTrigger();
 }

--- a/src/MF_InputShifter/MFInputShifter.cpp
+++ b/src/MF_InputShifter/MFInputShifter.cpp
@@ -32,7 +32,7 @@ bool MFInputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin,
         return false;
     
     _lastState = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
-    for (uint8_t i = 0; i++; i < _moduleCount) {
+    for (uint8_t i = 0; i < _moduleCount; i++) {
         _lastState[i] = 0;
     }
     _initialized = true;

--- a/src/MF_InputShifter/MFInputShifter.cpp
+++ b/src/MF_InputShifter/MFInputShifter.cpp
@@ -5,6 +5,7 @@
 //
 
 #include "MFInputShifter.h"
+#include "allocateMem.h"
 
 inputShifterEvent MFInputShifter::_inputHandler = NULL;
 
@@ -15,7 +16,7 @@ MFInputShifter::MFInputShifter()
 
 // Registers a new input shifter and configures the clock, data and latch pins as well
 // as the number of modules to read from.
-void MFInputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount, const char *name)
+bool MFInputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount, const char *name)
 {
     _latchPin    = latchPin;
     _clockPin    = clockPin;
@@ -26,10 +27,20 @@ void MFInputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin,
     pinMode(_latchPin, OUTPUT);
     pinMode(_clockPin, OUTPUT);
     pinMode(_dataPin, INPUT);
+
+    if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
+        return false;
+    
+    _lastState = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
+    for (uint8_t i = 0; i++; i < _moduleCount) {
+        _lastState[i] = 0;
+    }
     _initialized = true;
 
     // And now initialize all buttons with the actual status
     poll(DONT_TRIGGER);
+
+    return true;
 }
 
 // Reads the values from the attached modules, compares them to the previously

--- a/src/MF_InputShifter/MFInputShifter.h
+++ b/src/MF_InputShifter/MFInputShifter.h
@@ -8,11 +8,6 @@
 
 #include <Arduino.h>
 
-// Maximum number of shifters allowed on an individual chain. While this is currently set to 4
-// there is no technical limit in the code for how many can be chained. It is constrained only
-// by available memory (one byte required per chip) and the time it takes to read all the bits in.
-#define MAX_CHAINED_INPUT_SHIFTERS 4
-
 extern "C" {
 typedef void (*inputShifterEvent)(byte, uint8_t, const char *);
 };
@@ -26,7 +21,7 @@ class MFInputShifter
 {
 public:
     MFInputShifter();
-    void        attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount, const char *name);
+    bool        attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount, const char *name);
     static void attachHandler(inputShifterEvent newHandler);
     void        clear();
     void        detach();
@@ -42,8 +37,8 @@ private:
     uint8_t     _clockPin;    // CLK (clock) pin
     uint8_t     _dataPin;     // SDO (data) pin
     uint8_t     _moduleCount; // Number of 8 bit modules in series.
-    bool        _initialized                           = false;
-    uint8_t     _lastState[MAX_CHAINED_INPUT_SHIFTERS] = {0};
+    bool        _initialized = false;
+    uint8_t     *_lastState;
 
     void                     poll(uint8_t doTrigger);
     void                     detectChanges(uint8_t lastState, uint8_t currentState, uint8_t module);

--- a/src/MF_OutputShifter/MFOutputShifter.cpp
+++ b/src/MF_OutputShifter/MFOutputShifter.cpp
@@ -5,6 +5,7 @@
 //
 
 #include "MFOutputShifter.h"
+#include "allocateMem.h"
 
 MFOutputShifter::MFOutputShifter()
 {
@@ -39,7 +40,7 @@ void MFOutputShifter::setPins(char *pins, uint8_t value)
     updateShiftRegister();
 }
 
-void MFOutputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount)
+bool MFOutputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount)
 {
     _initialized = true;
     _latchPin    = latchPin;
@@ -51,12 +52,18 @@ void MFOutputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin
     pinMode(_clockPin, OUTPUT);
     pinMode(_dataPin, OUTPUT);
 
+    if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
+        return false;
+
+    _outputBuffer = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
+
     clear();
+
+    return true;
 }
 
 void MFOutputShifter::detach()
 {
-    if (!_initialized) return;
     _initialized = false;
 }
 

--- a/src/MF_OutputShifter/MFOutputShifter.cpp
+++ b/src/MF_OutputShifter/MFOutputShifter.cpp
@@ -69,26 +69,10 @@ void MFOutputShifter::detach()
 
 void MFOutputShifter::clear()
 {
-    // Set everything to 0
     for (uint8_t i = 0; i < _moduleCount; i++) {
         _outputBuffer[i] = 0;
     }
     updateShiftRegister();
-}
-
-void MFOutputShifter::test()
-{
-    for (uint8_t b = 0; b < _moduleCount * 8; b++) {
-        uint8_t idx        = (b & 0xF8) >> 3;
-        uint8_t msk        = (0x01 << (b & 0x07));
-        _outputBuffer[idx] = msk;
-        if (msk == 0x01 && idx != 0) _outputBuffer[idx - 1] = 0x00;
-        updateShiftRegister();
-        delay(50);
-
-        _outputBuffer[_moduleCount - 1] = 0;
-        updateShiftRegister();
-    }
 }
 
 void MFOutputShifter::updateShiftRegister()

--- a/src/MF_OutputShifter/MFOutputShifter.h
+++ b/src/MF_OutputShifter/MFOutputShifter.h
@@ -17,7 +17,6 @@ public:
     bool attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount);
     void detach();
     void clear();
-    void test();
     void updateShiftRegister();
 
 private:

--- a/src/MF_OutputShifter/MFOutputShifter.h
+++ b/src/MF_OutputShifter/MFOutputShifter.h
@@ -8,18 +8,13 @@
 
 #include <Arduino.h>
 
-// Maximum number of shifters allowed on an individual chain. While this is currently set to 4
-// there is no technical limit in the code for how many can be chained. It is constrained only
-// by available memory (one byte required per chip) and the time it takes to push all the bits out.
-#define MAX_CHAINED_OUTPUT_SHIFTERS 4
-
 class MFOutputShifter
 {
 public:
     MFOutputShifter();
     void setPin(uint8_t pin, uint8_t value, uint8_t refresh = 1);
     void setPins(char *pins, uint8_t value);
-    void attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount);
+    bool attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t moduleCount);
     void detach();
     void clear();
     void test();
@@ -30,7 +25,7 @@ private:
     uint8_t _clockPin;    // Clock pin
     uint8_t _dataPin;     // Data/SI pin
     uint8_t _moduleCount; // Number of 8 bit modules in series. For a shift register with 16 bit one needs to select 2 modules a 8......
-    uint8_t _outputBuffer[MAX_CHAINED_OUTPUT_SHIFTERS];
+    uint8_t *_outputBuffer;
     bool    _initialized = false;
 };
 

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -30,10 +30,9 @@ namespace OutputShifter
         outputShifters[outputShifterRegistered] = MFOutputShifter();
         if (!outputShifters[outputShifterRegistered].attach(latchPin, clockPin, dataPin, modules))
         {
-            cmdMessenger.sendCmd(kStatus, F("OutputShifter array does not fit in Memory"));
+            cmdMessenger.sendCmd(kStatus, F("OutputShifter array does not fit into Memory"));
             return;
         }
-        outputShifters[outputShifterRegistered].clear();
         outputShifterRegistered++;
 
 #ifdef DEBUG2CMDMESSENGER
@@ -51,12 +50,6 @@ namespace OutputShifter
 #ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kDebug, F("Cleared Output Shifter"));
 #endif
-    }
-
-    void OnInit() // not used anywhere!?
-    {
-        int module = cmdMessenger.readInt16Arg();
-        outputShifters[module].clear();
     }
 
     void OnSet()

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -28,7 +28,11 @@ namespace OutputShifter
         if (outputShifterRegistered == maxOutputShifter)
             return;
         outputShifters[outputShifterRegistered] = MFOutputShifter();
-        outputShifters[outputShifterRegistered].attach(latchPin, clockPin, dataPin, modules);
+        if (!outputShifters[outputShifterRegistered].attach(latchPin, clockPin, dataPin, modules))
+        {
+            cmdMessenger.sendCmd(kStatus, F("OutputShifter array does not fit in Memory"));
+            return;
+        }
         outputShifters[outputShifterRegistered].clear();
         outputShifterRegistered++;
 

--- a/src/MF_OutputShifter/OutputShifter.h
+++ b/src/MF_OutputShifter/OutputShifter.h
@@ -11,7 +11,6 @@ namespace OutputShifter
     bool setupArray(uint16_t count);
     void Add(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t modules);
     void Clear();
-    // void OnInit();        // this is defined but not used!?
     void OnSet();
 }
 


### PR DESCRIPTION
## Description of changes
For input and output shifter the statically initialized buffer is replaced by a dynamcally initialization on runtime with the size of chained 8bit shifter. The required memory will be in the device buffer as all deiveces.
This allows to use more than four 8bit shifter in one chain.
See also https://github.com/MobiFlight/MobiFlight-Connector/issues/1323

Additionally small code clean up is done.

Fixes #291
