### PR TITLE
Handling Custom Device versions

### DIFF
--- a/get_CustomDevices.py
+++ b/get_CustomDevices.py
@@ -3,7 +3,8 @@ import os
 Import("env")
 
 CUSTOMDEVICES_DIR = env.subst("$PROJECT_DIR/CustomDevices")
-CUSTOMDEVICES_TAG = "0.2.0"
+#CUSTOMDEVICES_TAG = "0.2.0"
+CUSTOMDEVICES_TAG = "main"
 
 if not os.path.exists(CUSTOMDEVICES_DIR):
     print ("Cloning Mobiflight-CustomDevices repo ... ")

--- a/get_CustomDevices.py
+++ b/get_CustomDevices.py
@@ -3,7 +3,7 @@ import os
 Import("env")
 
 CUSTOMDEVICES_DIR = env.subst("$PROJECT_DIR/CustomDevices")
-CUSTOMDEVICES_TAG = "0.2.0"
+CUSTOMDEVICES_TAG = "set_custom_version"
 
 if not os.path.exists(CUSTOMDEVICES_DIR):
     print ("Cloning Mobiflight-CustomDevices repo ... ")

--- a/get_CustomDevices.py
+++ b/get_CustomDevices.py
@@ -3,7 +3,7 @@ import os
 Import("env")
 
 CUSTOMDEVICES_DIR = env.subst("$PROJECT_DIR/CustomDevices")
-CUSTOMDEVICES_TAG = "set_custom_version"
+CUSTOMDEVICES_TAG = "0.2.0"
 
 if not os.path.exists(CUSTOMDEVICES_DIR):
     print ("Cloning Mobiflight-CustomDevices repo ... ")

--- a/get_version.py
+++ b/get_version.py
@@ -2,30 +2,41 @@ Import("env")
 import os
 
 # Get the version number from the build environment.
-firmware_version = os.environ.get('VERSION', "")
+core_firmware_version = os.environ.get('VERSION', "")
 custom_firmware_version = env.GetProjectOption("custom_firmware_version")
 
 # Clean up the version number
-if firmware_version == "":
+if core_firmware_version == "":
   # When no version is specified default to "0.0.1" for
   # compatibility with MobiFlight desktop app version checks.
-  firmware_version = "0.0.1"
+  core_firmware_version = "0.0.1"
+
+# Set the output filename to the name of the board and the version
+if custom_firmware_version == "":
+  custom_firmware_version = core_firmware_version
 
 # Strip any leading "v" that might be on the version and
 # any leading or trailing periods.
-firmware_version = firmware_version.lstrip("v")
-firmware_version = firmware_version.strip(".")
+core_firmware_version = core_firmware_version.lstrip("v")
+core_firmware_version = core_firmware_version.strip(".")
 
-print(f'Using version {firmware_version} for the build')
+print(f'Using version {core_firmware_version} for the build')
 
 # Append the version to the build defines so it gets baked into the firmware
 env.Append(CPPDEFINES=[
-  f'BUILD_VERSION={firmware_version}',
-  f'CUSTOM_BUILD_VERSION={custom_firmware_version}'
-])
+    f'CORE_BUILD_VERSION={core_firmware_version}'
+  ])
+if custom_firmware_version == "":
+  env.Append(CPPDEFINES=[
+    f'BUILD_VERSION={core_firmware_version}'
+  ])
+else:
+  env.Append(CPPDEFINES=[
+    f'BUILD_VERSION={custom_firmware_version}'
+  ])
 
 # Set the output filename to the name of the board and the version
-if custom_firmware_version != "":
-  firmware_version = custom_firmware_version
-
-env.Replace(PROGNAME=f'{env["PIOENV"]}_{firmware_version.replace(".", "_")}')
+if custom_firmware_version == "":
+  env.Replace(PROGNAME=f'{env["PIOENV"]}_{core_firmware_version.replace(".", "_")}')
+else:
+  env.Replace(PROGNAME=f'{env["PIOENV"]}_{custom_firmware_version.replace(".", "_")}')

--- a/get_version.py
+++ b/get_version.py
@@ -10,6 +10,10 @@ if firmware_version == "":
   # compatibility with MobiFlight desktop app version checks.
   firmware_version = "0.0.1"
 
+# But override if a custom version is defined
+if env.GetProjectOption("custom_firmware_version") != "":
+  firmware_version = env.GetProjectOption("custom_firmware_version")
+
 # Strip any leading "v" that might be on the version and
 # any leading or trailing periods.
 firmware_version = firmware_version.lstrip("v")

--- a/get_version.py
+++ b/get_version.py
@@ -3,16 +3,13 @@ import os
 
 # Get the version number from the build environment.
 firmware_version = os.environ.get('VERSION', "")
+custom_firmware_version = env.GetProjectOption("custom_firmware_version")
 
 # Clean up the version number
 if firmware_version == "":
   # When no version is specified default to "0.0.1" for
   # compatibility with MobiFlight desktop app version checks.
   firmware_version = "0.0.1"
-
-# But override if a custom version is defined
-if env.GetProjectOption("custom_firmware_version") != "":
-  firmware_version = env.GetProjectOption("custom_firmware_version")
 
 # Strip any leading "v" that might be on the version and
 # any leading or trailing periods.
@@ -23,8 +20,12 @@ print(f'Using version {firmware_version} for the build')
 
 # Append the version to the build defines so it gets baked into the firmware
 env.Append(CPPDEFINES=[
-  f'BUILD_VERSION={firmware_version}'
+  f'BUILD_VERSION={firmware_version}',
+  f'CUSTOM_BUILD_VERSION={custom_firmware_version}'
 ])
 
 # Set the output filename to the name of the board and the version
+if custom_firmware_version != "":
+  firmware_version = custom_firmware_version
+
 env.Replace(PROGNAME=f'{env["PIOENV"]}_{firmware_version.replace(".", "_")}')

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ extra_configs =
 	./CustomDevices/_all_CustomDevices/all_devices_platformio.ini
 	
 
-; Common build settings across all devices
+; Common build settings across all devices, also for the custom devices!
 [env]
 lib_deps = 
 	waspinator/AccelStepper @ 1.61

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,6 +58,7 @@ build_src_filter =
 extra_scripts =
 	pre:get_version.py
 	pre:get_CustomDevices.py
+custom_firmware_version =
 
 ; Build settings for the Arduino Mega
 [env:mobiflight_mega]
@@ -76,7 +77,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version =
+custom_firmware_version = ${env.custom_firmware_version}
 
 ; Build settings for the Arduino Pro Micro
 [env:mobiflight_micro]
@@ -95,7 +96,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = 
+custom_firmware_version = ${env.custom_firmware_version}
 
 ; Build settings for the Arduino Uno
 [env:mobiflight_uno]
@@ -114,7 +115,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = 
+custom_firmware_version = ${env.custom_firmware_version}
 
 ; Build settings for the Arduino Nano
 [env:mobiflight_nano]
@@ -133,7 +134,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = 
+custom_firmware_version = ${env.custom_firmware_version}
 
 ; Build settings for the Raspberry Pico original
 [env:mobiflight_raspberrypico]
@@ -157,4 +158,4 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = 
+custom_firmware_version = ${env.custom_firmware_version}

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Mega
-	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
+	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -76,8 +76,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = 0.9.1
-;custom_firmware_version =
+custom_firmware_version =
 
 ; Build settings for the Arduino Pro Micro
 [env:mobiflight_micro]
@@ -87,7 +86,7 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_ProMicro
-	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
+	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -106,7 +105,7 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Uno
-	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
+	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -125,7 +124,7 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Nano
-	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
+	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps =
@@ -149,7 +148,7 @@ upload_protocol = mbed									; for debugging upoading can be changed to picopr
 build_flags =
 	${env.build_flags}
 	-I./_Boards/RaspberryPi/Pico
-	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
+	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter =
 	${env.build_src_filter}
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -78,7 +78,6 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = ${env.custom_firmware_version}
 
 ; Build settings for the Arduino Pro Micro
 [env:mobiflight_micro]
@@ -96,7 +95,6 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = ${env.custom_firmware_version}
 
 ; Build settings for the Arduino Uno
 [env:mobiflight_uno]
@@ -114,7 +112,6 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = ${env.custom_firmware_version}
 
 ; Build settings for the Arduino Nano
 [env:mobiflight_nano]
@@ -132,7 +129,6 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = ${env.custom_firmware_version}
 
 ; Build settings for the Raspberry Pico original
 [env:mobiflight_raspberrypico]
@@ -155,4 +151,3 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = ${env.custom_firmware_version}

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,6 +67,7 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Mega
+	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -75,7 +76,8 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-custom_firmware_version = 3.2.1
+custom_firmware_version = 0.9.1
+;custom_firmware_version =
 
 ; Build settings for the Arduino Pro Micro
 [env:mobiflight_micro]
@@ -85,6 +87,7 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_ProMicro
+	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -103,6 +106,7 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Uno
+	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -121,6 +125,7 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Nano
+	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps =
@@ -144,6 +149,7 @@ upload_protocol = mbed									; for debugging upoading can be changed to picopr
 build_flags =
 	${env.build_flags}
 	-I./_Boards/RaspberryPi/Pico
+	-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter =
 	${env.build_src_filter}
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -75,6 +75,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
+custom_firmware_version = 3.2.1
 
 ; Build settings for the Arduino Pro Micro
 [env:mobiflight_micro]
@@ -92,7 +93,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
-
+custom_firmware_version = 
 
 ; Build settings for the Arduino Uno
 [env:mobiflight_uno]
@@ -110,6 +111,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
+custom_firmware_version = 
 
 ; Build settings for the Arduino Nano
 [env:mobiflight_nano]
@@ -127,6 +129,7 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
+custom_firmware_version = 
 
 ; Build settings for the Raspberry Pico original
 [env:mobiflight_raspberrypico]
@@ -149,3 +152,4 @@ lib_deps =
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}
+custom_firmware_version = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,8 @@ lib_deps =
 	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
 custom_lib_deps_Atmel =
 	arduino-libraries/Servo @ 1.1.8
+custom_lib_deps_Pico =
+	ricaun/ArduinoUniqueID @ ^1.3.0
 build_flags =
 	-DMF_REDUCE_FUNCT_LEDCONTROL
 	-DMAXCALLBACKS=35
@@ -68,7 +70,6 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Mega
-	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -87,7 +88,6 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_ProMicro
-	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -106,7 +106,6 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Uno
-	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps = 
@@ -125,7 +124,6 @@ framework = arduino
 build_flags = 
 	${env.build_flags}
 	-I./_Boards/Atmel/Board_Nano
-	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter = 
 	${env.build_src_filter}
 lib_deps =
@@ -149,12 +147,11 @@ upload_protocol = mbed									; for debugging upoading can be changed to picopr
 build_flags =
 	${env.build_flags}
 	-I./_Boards/RaspberryPi/Pico
-	;-DCUSTOM_FIRMWARE_VERSION=${this.custom_firmware_version}
 build_src_filter =
 	${env.build_src_filter}
 lib_deps =
 	${env.lib_deps}
-	ricaun/ArduinoUniqueID @ ^1.3.0
+	${env.custom_lib_deps_Pico}
 monitor_speed = 115200
 extra_scripts = 
 	${env.extra_scripts}

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -45,9 +45,10 @@
 #endif
 
 // The build version comes from an environment variable
-#define STRINGIZER(arg) #arg
-#define STR_VALUE(arg)  STRINGIZER(arg)
-#define VERSION         STR_VALUE(BUILD_VERSION)
+#define STRINGIZER(arg)    #arg
+#define STR_VALUE(arg)     STRINGIZER(arg)
+#define VERSION            STR_VALUE(BUILD_VERSION)
+#define CUSTOM_VERSION     STR_VALUE(CUSTOM_BUILD_VERSION)
 
 MFEEPROM MFeeprom;
 
@@ -553,6 +554,9 @@ void OnGetInfo()
     cmdMessenger.sendCmdArg(F(MOBIFLIGHT_TYPE));
     cmdMessenger.sendCmdArg(name);
     cmdMessenger.sendCmdArg(serial);
+#ifdef CUSTOM_BUILD_VERSION
+    cmdMessenger.sendCmdArg(CUSTOM_VERSION);
+#endif
     cmdMessenger.sendCmdArg(VERSION);
     cmdMessenger.sendCmdEnd();
 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -48,7 +48,7 @@
 #define STRINGIZER(arg)    #arg
 #define STR_VALUE(arg)     STRINGIZER(arg)
 #define VERSION            STR_VALUE(BUILD_VERSION)
-#define CUSTOM_VERSION     STR_VALUE(CUSTOM_BUILD_VERSION)
+#define CORE_VERSION       STR_VALUE(CORE_BUILD_VERSION)
 
 MFEEPROM MFeeprom;
 
@@ -554,10 +554,8 @@ void OnGetInfo()
     cmdMessenger.sendCmdArg(F(MOBIFLIGHT_TYPE));
     cmdMessenger.sendCmdArg(name);
     cmdMessenger.sendCmdArg(serial);
-#ifdef CUSTOM_BUILD_VERSION
-    cmdMessenger.sendCmdArg(CUSTOM_VERSION);
-#endif
     cmdMessenger.sendCmdArg(VERSION);
+    cmdMessenger.sendCmdArg(CORE_VERSION);
     cmdMessenger.sendCmdEnd();
 }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -45,10 +45,10 @@
 #endif
 
 // The build version comes from an environment variable
-#define STRINGIZER(arg)    #arg
-#define STR_VALUE(arg)     STRINGIZER(arg)
-#define VERSION            STR_VALUE(BUILD_VERSION)
-#define CORE_VERSION       STR_VALUE(CORE_BUILD_VERSION)
+#define STRINGIZER(arg) #arg
+#define STR_VALUE(arg)  STRINGIZER(arg)
+#define VERSION         STR_VALUE(BUILD_VERSION)
+#define CORE_VERSION    STR_VALUE(CORE_BUILD_VERSION)
 
 MFEEPROM MFeeprom;
 


### PR DESCRIPTION
## Description of changes

An additional flag `custom_firmware_version =` has been added to the standard environment `[env]` and is used for all standard boards as it gets not overwritten (no additional flag in the boards environment).
The custom device `.ini` files do have also this additional flag, but for each board a different version can be defined (or even the same, but than it should be changed into a common definition).

The `get_version.py` script checks if this additinal flag has a value, and if so this value is used for the firmware version within the filename. Otherwise the built version is used as for the filename as before.

Within `OnGetInfo()` both informations, the new flag and the existing built version, are send back to the connector.
First the new flag is send back as before, so it's still the firmware version. But it could be another one than for the standard boards. Additional the built version is send back which reflects the _core version_ on which the FW is based. This is still required to check which functionalities the board supports (changing name, custom devices, ...)
An example message for `OnGetInfo()` could be:
```
10,Kav Mega,MobiFlight Mega,SN-3ED-CB1,1.0.5,2.5.0;
```
In this case  `custom_firmware_version = 1.0.5` was defined.

If nothing is defined, the response would be:
```
10,Kav Mega,MobiFlight Mega,SN-3ED-CB1,2.5.0,2.5.0;
```

Changes in the connector would also be required to evaluate the additonal message as `core version` to check for functionalities. For now the connector just ignores the additional message, in case of a custom device with a "low" version some functions are not available.

CAUTION! The `get_CustomDevices.py` script is changed temporarily to download the `main' branch from the custom device repo. The changes in this repo are required to get it compiled. Once these changes are part of the next release from the custom device repo, this has to be implemented in this script.