### PR TITLE
Don't delete config if UniqueID was used for AVR's

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -88,7 +88,7 @@ bool readConfigLength()
     configLength        = 0;
 
     if (MFeeprom.read_byte(MEM_OFFSET_CONFIG) == 0xFF)
-        return;
+        return false;
     while (MFeeprom.read_byte(addreeprom++) != 0x00) {
         configLength++;
         if (addreeprom > length) {

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -87,6 +87,8 @@ bool readConfigLength()
     uint16_t length     = MFeeprom.get_length();
     configLength        = 0;
 
+    if (MFeeprom.read_byte(MEM_OFFSET_CONFIG) == 0xFF)
+        return;
     while (MFeeprom.read_byte(addreeprom++) != 0x00) {
         configLength++;
         if (addreeprom > length) {
@@ -619,13 +621,17 @@ void generateSerial(bool force)
         MFeeprom.read_block(MEM_OFFSET_SERIAL, serial, MEM_LEN_SERIAL);
         return;
     }
-#if defined(ARDUINO_ARCH_RP2040)
+
     // A uniqueID is already generated and saved to the eeprom
     if (MFeeprom.read_byte(MEM_OFFSET_SERIAL) == 'I' && MFeeprom.read_byte(MEM_OFFSET_SERIAL + 1) == 'D') {
+#if defined(ARDUINO_ARCH_AVR)
+        generateRandomSerial();
+#elif defined(ARDUINO_ARCH_RP2040)
         readUniqueSerial();
+#endif
         return;
     }
-#endif
+
 
     // Coming here no UniqueID and no serial number is available, so it's the first start up of a board
 #if defined(ARDUINO_ARCH_AVR)
@@ -633,16 +639,16 @@ void generateSerial(bool force)
     // To have not always the same starting point for the random generator, millis() are
     // used as starting point. It is very unlikely that the time between flashing the firmware
     // and getting the command to send the info's to the connector is always the same.
-    generateRandomSerial();
+    // additional double check if it's really a new board, should reduce Jaimes problem
+    if (MFeeprom.read_byte(MEM_OFFSET_CONFIG) == 0xFF) {
+        generateRandomSerial();
+    }
 #elif defined(ARDUINO_ARCH_RP2040)
     // Read the uniqueID for Pico's and use it as serial number
     readUniqueSerial();
     // mark this in the eeprom that a UniqueID is used on first start up for Pico's
     MFeeprom.write_block(MEM_OFFSET_SERIAL, "ID", 2);
 #endif
-    // Set first byte of config to 0x00 to ensure empty config on 1st start up
-    // Otherwise the complete length of the config will be send with 0xFF (empty EEPROM)
-    MFeeprom.write_byte(MEM_OFFSET_CONFIG, 0x00);
 }
 
 void OnGenNewSerial()

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -590,7 +590,7 @@ void generateRandomSerial()
         randomSerial >>= 4;
     }
     MFeeprom.write_block(MEM_OFFSET_SERIAL, serial, MEM_LEN_SERIAL);
-    cmdMessenger.sendCmd(kInfo, F("Serial number generated"));
+    cmdMessenger.sendCmd(kDebug, F("Serial number generated"));
 }
 
 #if defined(ARDUINO_ARCH_RP2040)

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -640,15 +640,16 @@ void generateSerial(bool force)
     // used as starting point. It is very unlikely that the time between flashing the firmware
     // and getting the command to send the info's to the connector is always the same.
     // additional double check if it's really a new board, should reduce Jaimes problem
-    if (MFeeprom.read_byte(MEM_OFFSET_CONFIG) == 0xFF) {
-        generateRandomSerial();
-    }
+    generateRandomSerial();
 #elif defined(ARDUINO_ARCH_RP2040)
     // Read the uniqueID for Pico's and use it as serial number
     readUniqueSerial();
     // mark this in the eeprom that a UniqueID is used on first start up for Pico's
     MFeeprom.write_block(MEM_OFFSET_SERIAL, "ID", 2);
 #endif
+    if (MFeeprom.read_byte(MEM_OFFSET_CONFIG) == 0xFF) {
+        MFeeprom.write_block(MEM_OFFSET_CONFIG, 0x00);
+    }
 }
 
 void OnGenNewSerial()

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -590,6 +590,7 @@ void generateRandomSerial()
         randomSerial >>= 4;
     }
     MFeeprom.write_block(MEM_OFFSET_SERIAL, serial, MEM_LEN_SERIAL);
+    cmdMessenger.sendCmd(kInfo, F("Serial number generated"));
 }
 
 #if defined(ARDUINO_ARCH_RP2040)


### PR DESCRIPTION
## Description of changes

On a short period of time UniqueID was used for AVR's. This was rolled back and it was intended to generate a new serial number. Unfortenutely this wasn't introduced, instead a new board was detected and the config was deleted by writing 0x00 to the first location of the config in the EEPROM.
With this a serial number gets generated if a UniqueID is used for AVR's. Additionally it's checked if it's a first time starting up this board by checking the first eeprom loation for the config. It must be 0xFF (blank EEPROM), otherwise it is assumed that reading the serial number failed. In this case no new serial number is generated.
Deleting the config will not be done anymore.

On a first start up of the board the EEPROM contains always 0xFF. If the config get's read from the connector, all 0xFF up to the MEMLEN_CONFIG gets transferred. This is changed, it is checked if the first Byte of the config is 0xFF, in this case an empty config is assumed and no config gets transferred to the connector.

Fixes #313 