### PR TITLE
Read config from EEPROM only if no config is in Flash

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -130,7 +130,8 @@ void OnSetConfig()
     char   *cfg    = cmdMessenger.readStringArg();
     uint8_t cfgLen = strlen(cfg);
 
-    if (configLengthEEPROM + cfgLen + 1 < MEM_LEN_CONFIG) {
+   bool maxConfigLengthNotExceeded = configLengthEEPROM + cfgLen + 1 < MEM_LEN_CONFIG;
+    if (maxConfigLengthNotExceeded) {
         MFeeprom.write_block(MEM_OFFSET_CONFIG + configLengthEEPROM, cfg, cfgLen + 1); // save the received config string including the terminatung NULL (+1) to EEPROM
         configLengthEEPROM += cfgLen;
         cmdMessenger.sendCmd(kStatus, configLengthEEPROM);

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -84,6 +84,14 @@ void resetConfig();
 void readConfig();
 void _activateConfig();
 void readConfigFromMemory(bool configFromFlash);
+bool configStoredInFlash()
+{
+    return configLengthFlash > 0;
+}
+bool configStoredInEEPROM()
+{
+    return configLengthEEPROM > 0;
+}
 
 // ************************************************************
 // configBuffer handling
@@ -130,7 +138,7 @@ void OnSetConfig()
     char   *cfg    = cmdMessenger.readStringArg();
     uint8_t cfgLen = strlen(cfg);
 
-   bool maxConfigLengthNotExceeded = configLengthEEPROM + cfgLen + 1 < MEM_LEN_CONFIG;
+    bool maxConfigLengthNotExceeded = configLengthEEPROM + cfgLen + 1 < MEM_LEN_CONFIG;
     if (maxConfigLengthNotExceeded) {
         MFeeprom.write_block(MEM_OFFSET_CONFIG + configLengthEEPROM, cfg, cfgLen + 1); // save the received config string including the terminatung NULL (+1) to EEPROM
         configLengthEEPROM += cfgLen;
@@ -363,17 +371,17 @@ void InitArrays(uint8_t *numberDevices)
 void readConfig()
 {
     uint8_t numberDevices[kTypeMax] = {0};
-    if (configLengthEEPROM > 0) {
-        GetArraySizes(numberDevices, false);
-    } else if (configLengthFlash > 0) {
-        GetArraySizes(numberDevices, true);
+
+    // Early return if no valid configuration is found
+    if (!configStoredInFlash() && !configStoredInEEPROM()) {
+        InitArrays(numberDevices);
+        return;
     }
+
+    // Determine which configuration to use and proceed
+    GetArraySizes(numberDevices, configStoredInFlash());
     InitArrays(numberDevices);
-    if (configLengthFlash > 0) {
-        readConfigFromMemory(true);
-    } else if (configLengthEEPROM > 0) {
-        readConfigFromMemory(false);
-    }
+    readConfigFromMemory(configStoredInFlash());
 }
 
 void readConfigFromMemory(bool configFromFlash)
@@ -574,12 +582,12 @@ void readConfigFromMemory(bool configFromFlash)
 void OnGetConfig()
 {
     cmdMessenger.sendCmdStart(kInfo);
-    if (configLengthEEPROM > 0) {
+    if (configStoredInEEPROM()) {
         cmdMessenger.sendCmdArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG));
         for (uint16_t i = 1; i < configLengthEEPROM; i++) {
             cmdMessenger.sendArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG + i));
         }
-    } else if (configLengthFlash > 0) {
+    } else if (configStoredInFlash()) {
         cmdMessenger.sendCmdArg((char)pgm_read_byte_near(CustomDeviceConfig));
         for (uint16_t i = 1; i < (configLengthFlash - 1); i++) {
             cmdMessenger.sendArg((char)pgm_read_byte_near(CustomDeviceConfig + i));
@@ -709,7 +717,7 @@ void OnGenNewSerial()
 // ************************************************************
 void storeName()
 {
-    if (configLengthFlash != 0) {
+    if (!configStoredInFlash()) {
         MFeeprom.write_byte(MEM_OFFSET_NAME, '#');
         MFeeprom.write_block(MEM_OFFSET_NAME + 1, name, MEM_LEN_NAME - 1);
     }
@@ -726,7 +734,7 @@ void restoreName()
 void OnSetName()
 {
     char *cfg = cmdMessenger.readStringArg();
-    if (configLengthFlash != 0) {
+    if (!configStoredInFlash()) {
         memcpy(name, cfg, MEM_LEN_NAME);
         storeName();
     }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -122,7 +122,7 @@ void OnSetConfig()
 #ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmd(kDebug, F("Setting config start"));
 #endif
-    // A config can be in flash or in EEPROM, bur only one must be used
+    // A config can be in flash or in EEPROM, but only one option must be used
     // Once a config is in EEPROM, this config will be loaded and reported to the connector
     // If no config is in EEPROM, the config from flash will be used if available
     // This ensures backwards compatibility if a board gets updated with a config in flash

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -354,15 +354,13 @@ void readConfig()
     uint8_t numberDevices[kTypeMax] = {0};
     if (configLengthFlash > 0) {
         GetArraySizes(numberDevices, true);
-    }
-    if (configLengthEEPROM > 0) {
+    } else if (configLengthEEPROM > 0) {
         GetArraySizes(numberDevices, false);
     }
     InitArrays(numberDevices);
     if (configLengthFlash > 0) {
         readConfigFromMemory(true);
-    }
-    if (configLengthEEPROM > 0) {
+    } else if (configLengthEEPROM > 0) {
         readConfigFromMemory(false);
     }
 }
@@ -572,8 +570,7 @@ void OnGetConfig()
             cmdMessenger.sendArg((char)pgm_read_byte_near(CustomDeviceConfig + i));
         }
         sentFromFlash = true;
-    }
-    if (configLengthEEPROM > 0) {
+    } else if (configLengthEEPROM > 0) {
         if (sentFromFlash)
             cmdMessenger.sendArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG));
         else

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -122,22 +122,20 @@ void OnSetConfig()
 #ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmd(kDebug, F("Setting config start"));
 #endif
-    // For now a config can only be saved if NO config in flash is available
-    // otherwise a config from flash would be sent from the connector
-    // and saved in the EEPROM, so the config get's doubled
-    if (configLengthFlash == 0) {
-        char   *cfg    = cmdMessenger.readStringArg();
-        uint8_t cfgLen = strlen(cfg);
+    // A config can be in flash or in EEPROM, bur only one must be used
+    // Once a config is in EEPROM, this config will be loaded and reported to the connector
+    // If no config is in EEPROM, the config from flash will be used if available
+    // This ensures backwards compatibility if a board gets updated with a config in flash
+    // but also have a user config in EEPROM
+    char   *cfg    = cmdMessenger.readStringArg();
+    uint8_t cfgLen = strlen(cfg);
 
-        if (configLengthEEPROM + cfgLen + 1 < MEM_LEN_CONFIG) {
-            MFeeprom.write_block(MEM_OFFSET_CONFIG + configLengthEEPROM, cfg, cfgLen + 1); // save the received config string including the terminatung NULL (+1) to EEPROM
-            configLengthEEPROM += cfgLen;
-            cmdMessenger.sendCmd(kStatus, configLengthEEPROM);
-        } else
-            cmdMessenger.sendCmd(kStatus, -1); // last successfull saving block is already NULL terminated, nothing more todo
-    } else {
+    if (configLengthEEPROM + cfgLen + 1 < MEM_LEN_CONFIG) {
+        MFeeprom.write_block(MEM_OFFSET_CONFIG + configLengthEEPROM, cfg, cfgLen + 1); // save the received config string including the terminatung NULL (+1) to EEPROM
+        configLengthEEPROM += cfgLen;
         cmdMessenger.sendCmd(kStatus, configLengthEEPROM);
-    }
+    } else
+        cmdMessenger.sendCmd(kStatus, -1); // last successfull saving block is already NULL terminated, nothing more todo
 #ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmd(kDebug, F("Setting config end"));
 #endif
@@ -352,10 +350,10 @@ void InitArrays(uint8_t *numberDevices)
 void readConfig()
 {
     uint8_t numberDevices[kTypeMax] = {0};
-    if (configLengthFlash > 0) {
-        GetArraySizes(numberDevices, true);
-    } else if (configLengthEEPROM > 0) {
+    if (configLengthEEPROM > 0) {
         GetArraySizes(numberDevices, false);
+    } else if (configLengthFlash > 0) {
+        GetArraySizes(numberDevices, true);
     }
     InitArrays(numberDevices);
     if (configLengthFlash > 0) {
@@ -562,21 +560,16 @@ void readConfigFromMemory(bool configFromFlash)
 
 void OnGetConfig()
 {
-    bool sentFromFlash = false;
     cmdMessenger.sendCmdStart(kInfo);
-    if (configLengthFlash > 0) {
+    if (configLengthEEPROM > 0) {
+        cmdMessenger.sendCmdArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG));
+        for (uint16_t i = 1; i < configLengthEEPROM; i++) {
+            cmdMessenger.sendArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG + i));
+        }
+    } else if (configLengthFlash > 0) {
         cmdMessenger.sendCmdArg((char)pgm_read_byte_near(CustomDeviceConfig));
         for (uint16_t i = 1; i < (configLengthFlash - 1); i++) {
             cmdMessenger.sendArg((char)pgm_read_byte_near(CustomDeviceConfig + i));
-        }
-        sentFromFlash = true;
-    } else if (configLengthEEPROM > 0) {
-        if (sentFromFlash)
-            cmdMessenger.sendArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG));
-        else
-            cmdMessenger.sendCmdArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG));
-        for (uint16_t i = 1; i < configLengthEEPROM; i++) {
-            cmdMessenger.sendArg((char)MFeeprom.read_byte(MEM_OFFSET_CONFIG + i));
         }
     }
     cmdMessenger.sendCmdEnd();

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -693,8 +693,10 @@ void OnGenNewSerial()
 // ************************************************************
 void storeName()
 {
-    MFeeprom.write_byte(MEM_OFFSET_NAME, '#');
-    MFeeprom.write_block(MEM_OFFSET_NAME + 1, name, MEM_LEN_NAME - 1);
+    if (configLengthFlash != 0) {
+        MFeeprom.write_byte(MEM_OFFSET_NAME, '#');
+        MFeeprom.write_block(MEM_OFFSET_NAME + 1, name, MEM_LEN_NAME - 1);
+    }
 }
 
 void restoreName()
@@ -708,8 +710,10 @@ void restoreName()
 void OnSetName()
 {
     char *cfg = cmdMessenger.readStringArg();
-    memcpy(name, cfg, MEM_LEN_NAME);
-    storeName();
+    if (configLengthFlash != 0) {
+        memcpy(name, cfg, MEM_LEN_NAME);
+        storeName();
+    }
     cmdMessenger.sendCmd(kStatus, name);
 }
 


### PR DESCRIPTION
## Description of changes

If a configuration is already saved in the EEPROM, and the board gets updated with a new Firmware where the configuration is part of the flash, the exsiting configuration in the EEPROM gets ignored and only the one from the flash gets reported to the connector and loaded into the internal memory.

Before sending the configuration to the connector, it gets's checked if a configuration is stored in the flash. If this is the case (configLength > 0), this configuration is send to the connector. If no config in the flash is available (configLength = 0) but a config in the EEPROM saved, this config gets send to the connector.
The same applies for loading the config into the internal memory.

For now it is only checked if a configuration in the EEPROM `OR` Flash is available. If a configuration is saved, this one gets reported to the connector and loaded into the internal memory.

Fixes #326 