### PR TITLE
Stop 2nd core for pico during config upload

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -173,7 +173,13 @@ void resetConfig()
     DigInMux::Clear();
 #endif
 #if MF_CUSTOMDEVICE_SUPPORT == 1
+#if defined(USE_2ND_CORE)
+    CustomDevice::stopUpdate2ndCore(true);
+#endif
     CustomDevice::Clear();
+#if defined(USE_2ND_CORE)
+    CustomDevice::stopUpdate2ndCore(false);
+#endif
 #endif
     configLengthEEPROM = 0;
     configActivated    = false;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -155,7 +155,13 @@ void resetConfig()
     Servos::Clear();
 #endif
 #if MF_STEPPER_SUPPORT == 1
+#if defined(STEPPER_ON_2ND_CORE)
+    Stepper::stopUpdate2ndCore(true);
+#endif
     Stepper::Clear();
+#if defined(STEPPER_ON_2ND_CORE)
+    Stepper::stopUpdate2ndCore(false);
+#endif
 #endif
 #if MF_LCD_SUPPORT == 1
     LCDDisplay::Clear();

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -155,11 +155,11 @@ void resetConfig()
     Servos::Clear();
 #endif
 #if MF_STEPPER_SUPPORT == 1
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     Stepper::stopUpdate2ndCore(true);
 #endif
     Stepper::Clear();
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     Stepper::stopUpdate2ndCore(false);
 #endif
 #endif
@@ -179,11 +179,11 @@ void resetConfig()
     DigInMux::Clear();
 #endif
 #if MF_CUSTOMDEVICE_SUPPORT == 1
-#if defined(USE_2ND_CORE)
+#if defined(USE_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     CustomDevice::stopUpdate2ndCore(true);
 #endif
     CustomDevice::Clear();
-#if defined(USE_2ND_CORE)
+#if defined(USE_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     CustomDevice::stopUpdate2ndCore(false);
 #endif
 #endif

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -117,13 +117,15 @@ namespace CustomDevice
     {
         for (uint8_t i = 0; i < customDeviceRegistered; ++i) {
             if (state)
-                customDevice[i].set(MESSAGEID_POWERSAVINGMODE, (char*)"1");
+                customDevice[i].set(MESSAGEID_POWERSAVINGMODE, (char *)"1");
             else
-                customDevice[i].set(MESSAGEID_POWERSAVINGMODE, (char*)"0");
+                customDevice[i].set(MESSAGEID_POWERSAVINGMODE, (char *)"0");
         }
     }
 
-    void stopUpdate2ndCore(bool stop) {
+#if defined(STEPPER_ON_2ND_CORE)
+    void stopUpdate2ndCore(bool stop)
+    {
         // wait for 2nd core
         rp2040.fifo.pop();
         // send command to stop/start updating to 2nd core
@@ -136,6 +138,7 @@ namespace CustomDevice
         // wait for execution of command
         rp2040.fifo.pop();
     }
+#endif
 } // end of namespace
 
 #if defined(USE_2ND_CORE)
@@ -157,7 +160,7 @@ void loop1()
     int16_t device;
     int16_t messageID;
     char   *payload;
-    bool stopUpdating = false;
+    bool    stopUpdating = false;
 #ifdef MF_CUSTOMDEVICE_POLL_MS
     uint32_t lastMillis = 0;
 #endif
@@ -168,7 +171,7 @@ void loop1()
 #endif
 #if defined(MF_CUSTOMDEVICE_HAS_UPDATE)
             for (int i = 0; i < CustomDevice::customDeviceRegistered && !stopUpdating; i++) {
-                    CustomDevice::customDevice[i].update();
+                CustomDevice::customDevice[i].update();
             }
 #endif
 #ifdef MF_CUSTOMDEVICE_POLL_MS
@@ -181,7 +184,7 @@ void loop1()
             device    = (int16_t)rp2040.fifo.pop();
             messageID = (int16_t)rp2040.fifo.pop();
             payload   = (char *)rp2040.fifo.pop();
-            if (device == -1 ) {
+            if (device == -1) {
                 stopUpdating = (bool)messageID;
                 // inform core 0 that command has been executed
                 // it's additional needed in this case

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -1,7 +1,7 @@
 #include "mobiflight.h"
 #include "CustomDevice.h"
 #include "MFCustomDevice.h"
-#if defined(USE_2ND_CORE)
+#if defined(USE_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
 #include <FreeRTOS.h>
 #endif
 
@@ -92,7 +92,7 @@ namespace CustomDevice
         int16_t messageID = cmdMessenger.readInt16Arg();  // get the messageID number
         char   *output    = cmdMessenger.readStringArg(); // get the pointer to the new raw string
         cmdMessenger.unescape(output);                    // and unescape the string if escape characters are used
-#if defined(USE_2ND_CORE)
+#if defined(USE_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
         // copy the message, could get be overwritten from the next message while processing on 2nd core
         strncpy(payload, output, SERIAL_RX_BUFFER_SIZE);
         // wait for 2nd core
@@ -123,7 +123,7 @@ namespace CustomDevice
         }
     }
 
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     void stopUpdate2ndCore(bool stop)
     {
         // wait for 2nd core
@@ -141,7 +141,7 @@ namespace CustomDevice
 #endif
 } // end of namespace
 
-#if defined(USE_2ND_CORE)
+#if defined(USE_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
 /* **********************************************************************************
     This will run the set() function from the custom device on the 2nd core
     Be aware NOT to use the function calls from the Pico SDK!

--- a/src/MF_CustomDevice/CustomDevice.h
+++ b/src/MF_CustomDevice/CustomDevice.h
@@ -10,7 +10,7 @@ namespace CustomDevice
     void update();
     void OnSet();
     void PowerSave(bool state);
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     void stopUpdate2ndCore(bool stop);
 #endif
 }

--- a/src/MF_CustomDevice/CustomDevice.h
+++ b/src/MF_CustomDevice/CustomDevice.h
@@ -2,10 +2,13 @@
 
 namespace CustomDevice
 {
+    #define START_STOP_2ND_CORE -1
+
     bool setupArray(uint16_t count);
     void Add(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig, bool configFromFlash);
     void Clear();
     void update();
     void OnSet();
     void PowerSave(bool state);
+    void stopUpdate2ndCore(bool stop);
 }

--- a/src/MF_CustomDevice/CustomDevice.h
+++ b/src/MF_CustomDevice/CustomDevice.h
@@ -10,5 +10,7 @@ namespace CustomDevice
     void update();
     void OnSet();
     void PowerSave(bool state);
+#if defined(STEPPER_ON_2ND_CORE)
     void stopUpdate2ndCore(bool stop);
+#endif
 }

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -20,7 +20,8 @@ namespace Stepper
     enum {
         FUNC_MOVETO = 1,
         FUNC_ZETZERO,
-        FUNC_SPEEDACCEL
+        FUNC_SPEEDACCEL,
+        START_STOP_2ND_CORE
     };
 #endif
 
@@ -146,6 +147,21 @@ namespace Stepper
         }
     }
 
+#if defined(STEPPER_ON_2ND_CORE)
+    void stopUpdate2ndCore(bool stop)
+    {
+        // wait for 2nd core
+        rp2040.fifo.pop();
+        // send command to stop/start updating to 2nd core
+        rp2040.fifo.push(START_STOP_2ND_CORE);
+        // communication is always done using 4 messages
+        rp2040.fifo.push(0);
+        rp2040.fifo.push(stop);
+        rp2040.fifo.push(0);
+        // wait for execution of command
+        rp2040.fifo.pop();
+    }
+#endif
 } // namespace
 
 #if defined(STEPPER_ON_2ND_CORE)
@@ -158,32 +174,40 @@ namespace Stepper
 ********************************************************************************** */
 void setup1()
 {
-    rp2040.fifo.push(true); // inform core 1 to be ready
+    // send "ready" message to 1st core
+    rp2040.fifo.push(true);
 }
 
 void loop1()
 {
-    uint8_t  command, stepper;
+    uint8_t command, stepper;
     int32_t param1, param2;
+    bool    stopUpdating = false;
 
     while (1) {
-        for (uint8_t i = 0; i < Stepper::steppersRegistered; ++i) {
+        for (uint8_t i = 0; i < Stepper::steppersRegistered && !stopUpdating; ++i) {
             Stepper::steppers[i].update();
-            if (rp2040.fifo.available()) {
-                command = (uint8_t)rp2040.fifo.pop();
-                stepper = (uint8_t)rp2040.fifo.pop();
-                param1  = (int32_t)rp2040.fifo.pop();
-                param2  = (int32_t)rp2040.fifo.pop();
-                if (command == Stepper::FUNC_MOVETO) {
-                    Stepper::steppers[stepper].moveTo(param1);
-                } else if (command == Stepper::FUNC_ZETZERO) {
-                    Stepper::steppers[stepper].setZero();
-                } else if (command == Stepper::FUNC_SPEEDACCEL) {
-                    Stepper::steppers[stepper].setMaxSpeed(param1);
-                    Stepper::steppers[stepper].setAcceleration(param2);
-                }
-                rp2040.fifo.push(true); // inform core 1 to be ready for next command
+        }
+        if (rp2040.fifo.available()) {
+            command = (uint8_t)rp2040.fifo.pop();
+            stepper = (uint8_t)rp2040.fifo.pop();
+            param1  = (int32_t)rp2040.fifo.pop();
+            param2  = (int32_t)rp2040.fifo.pop();
+            if (command == Stepper::FUNC_MOVETO) {
+                Stepper::steppers[stepper].moveTo(param1);
+            } else if (command == Stepper::FUNC_ZETZERO) {
+                Stepper::steppers[stepper].setZero();
+            } else if (command == Stepper::FUNC_SPEEDACCEL) {
+                Stepper::steppers[stepper].setMaxSpeed(param1);
+                Stepper::steppers[stepper].setAcceleration(param2);
+            } else if (command == Stepper::START_STOP_2ND_CORE) {
+                stopUpdating = (bool)param1;
+                // inform core 0 that command has been executed
+                // it's additional needed in this case
+                rp2040.fifo.push(true);
             }
+            // send ready for next message to 1st core
+            rp2040.fifo.push(true);
         }
     }
 }

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -7,7 +7,7 @@
 #include "mobiflight.h"
 #include "MFStepper.h"
 #include "Stepper.h"
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
 #include <FreeRTOS.h>
 #endif
 
@@ -72,7 +72,7 @@ namespace Stepper
 
         if (stepper >= steppersRegistered)
             return;
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
         // wait for 2nd core
         rp2040.fifo.pop();
         rp2040.fifo.push(FUNC_MOVETO);
@@ -99,7 +99,7 @@ namespace Stepper
 
         if (stepper >= steppersRegistered)
             return;
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
         // wait for 2nd core
         rp2040.fifo.pop();
         rp2040.fifo.push(FUNC_ZETZERO);
@@ -119,7 +119,7 @@ namespace Stepper
 
         if (stepper >= steppersRegistered)
             return;
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
         rp2040.fifo.pop(); // wait for 2nd core
         rp2040.fifo.push(FUNC_SPEEDACCEL);
         rp2040.fifo.push(stepper);
@@ -147,7 +147,7 @@ namespace Stepper
         }
     }
 
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     void stopUpdate2ndCore(bool stop)
     {
         // wait for 2nd core
@@ -164,7 +164,7 @@ namespace Stepper
 #endif
 } // namespace
 
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
 /* **********************************************************************************
     This will run the set() function from the custom device on the 2nd core
     Be aware NOT to use the function calls from the Pico SDK!

--- a/src/MF_Stepper/Stepper.h
+++ b/src/MF_Stepper/Stepper.h
@@ -17,6 +17,9 @@ namespace Stepper
     void update();
     void OnSetSpeedAccel();
     void PowerSave(bool state);
+#if defined(STEPPER_ON_2ND_CORE)
+    void stopUpdate2ndCore(bool stop);
+#endif
 }
 
 // Stepper.h

--- a/src/MF_Stepper/Stepper.h
+++ b/src/MF_Stepper/Stepper.h
@@ -17,7 +17,7 @@ namespace Stepper
     void update();
     void OnSetSpeedAccel();
     void PowerSave(bool state);
-#if defined(STEPPER_ON_2ND_CORE)
+#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     void stopUpdate2ndCore(bool stop);
 #endif
 }


### PR DESCRIPTION
## Description of changes

If a custom device is defined which is running on the 2nd core from the Pico and this custom device has regular updates, the Pico crashes sometimes while uploading a new config file.
To fix this issue the update() function on the 2nd core has to be stopped before clearing the custom devices and uploading a new config file. After clearing the custom devices the flag is resetted. As no custom devices are defined anymore the update() function gets not called anymore and a new config file can be uploaded.

When uploading a new config, this config gets saved in the EEPROM. If the 2nd core of the Pico is used, this one has to be paused to write the changes to the Flash (EEPROM emulation). Afterwards the 2nd core can be run again.

A new function within CustomDevice.cpp is added. This function sends a message to the 2nd core of the Pico to stop updating the custom device. The function waits for a response from the 2nd core via the FiFo buffer.

Within the loop1() function it is checked, if a `stop updating` command is received, If so a flag is set and the custom device gets not updated anymore. Also it is checked if a `start updating` command is received and if so, the custom device can be updated again. In both cases the 1st core gets informed.

Within Config.cpp the `stop updating` function is called before clearing the custom devices. Afterwards the `start updating` function is called to enable updating custom devices again.

Fixes #328 