### PR TITLE
Pico uses always UniqueID

### DIFF
--- a/_Boards/Atmel/Board_Mega/MFBoards.h
+++ b/_Boards/Atmel/Board_Mega/MFBoards.h
@@ -39,9 +39,6 @@
 #ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Mega"
 #endif
-#ifndef MOBIFLIGHT_SERIAL
-#define MOBIFLIGHT_SERIAL   "1234567890"
-#endif
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Mega"
 #endif

--- a/_Boards/Atmel/Board_Nano/MFBoards.h
+++ b/_Boards/Atmel/Board_Nano/MFBoards.h
@@ -39,9 +39,6 @@
 #ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Nano"
 #endif
-#ifndef MOBIFLIGHT_SERIAL
-#define MOBIFLIGHT_SERIAL   "0987654321"
-#endif
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Nano"
 #endif

--- a/_Boards/Atmel/Board_ProMicro/MFBoards.h
+++ b/_Boards/Atmel/Board_ProMicro/MFBoards.h
@@ -39,9 +39,6 @@
 #ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Micro"
 #endif
-#ifndef MOBIFLIGHT_SERIAL
-#define MOBIFLIGHT_SERIAL   "0987654321"
-#endif
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Micro"
 #endif

--- a/_Boards/Atmel/Board_Uno/MFBoards.h
+++ b/_Boards/Atmel/Board_Uno/MFBoards.h
@@ -39,9 +39,6 @@
 #ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE     "MobiFlight Uno"
 #endif
-#ifndef MOBIFLIGHT_SERIAL
-#define MOBIFLIGHT_SERIAL   "0987654321"
-#endif
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME     "MobiFlight Uno"
 #endif

--- a/_Boards/RaspberryPi/Pico/MFBoards.h
+++ b/_Boards/RaspberryPi/Pico/MFBoards.h
@@ -33,9 +33,6 @@
 #ifndef MOBIFLIGHT_TYPE
 #define MOBIFLIGHT_TYPE         "MobiFlight RaspiPico"
 #endif
-#ifndef MOBIFLIGHT_SERIAL
-#define MOBIFLIGHT_SERIAL       "0987654321"
-#endif
 #ifndef MOBIFLIGHT_NAME
 #define MOBIFLIGHT_NAME         "MobiFlight RaspiPico"
 #endif

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -68,9 +68,9 @@ const uint8_t MEM_LEN_SERIAL    = 11;
 const uint8_t MEM_OFFSET_CONFIG = MEM_OFFSET_NAME + MEM_LEN_NAME + MEM_LEN_SERIAL;
 
 #if defined(ARDUINO_ARCH_AVR)
-char serial[11] = MOBIFLIGHT_SERIAL; // 3 characters for "SN-",7 characters for "xyz-zyx" plus terminating NULL
+char serial[11]; // 3 characters for "SN-",7 characters for "xyz-zyx" plus terminating NULL
 #elif defined(ARDUINO_ARCH_RP2040)
-char serial[3 + UniqueIDsize * 2 + 1] = MOBIFLIGHT_SERIAL; // 3 characters for "SN-", UniqueID as HEX String, terminating NULL
+char serial[3 + UniqueIDsize * 2 + 1]; // 3 characters for "SN-", UniqueID as HEX String, terminating NULL
 #endif
 char           name[MEM_LEN_NAME]              = MOBIFLIGHT_NAME;
 const int      MEM_LEN_CONFIG                  = MEMLEN_CONFIG;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -9,7 +9,7 @@
 #include "Button.h"
 #include "Encoder.h"
 #include "Output.h"
-#if defined(ARDUINO_ARCH_RP2040)
+#if !defined(ARDUINO_ARCH_AVR)
 #include "ArduinoUniqueID.h"
 #endif
 
@@ -69,7 +69,7 @@ const uint8_t MEM_OFFSET_CONFIG = MEM_OFFSET_NAME + MEM_LEN_NAME + MEM_LEN_SERIA
 
 #if defined(ARDUINO_ARCH_AVR)
 char serial[11]; // 3 characters for "SN-",7 characters for "xyz-zyx" plus terminating NULL
-#elif defined(ARDUINO_ARCH_RP2040)
+#else
 char serial[3 + UniqueIDsize * 2 + 1]; // 3 characters for "SN-", UniqueID as HEX String, terminating NULL
 #endif
 char           name[MEM_LEN_NAME]              = MOBIFLIGHT_NAME;
@@ -643,7 +643,7 @@ void generateRandomSerial()
 }
 #endif
 
-#if defined(ARDUINO_ARCH_RP2040)
+#if !defined(ARDUINO_ARCH_AVR)
 void readUniqueSerial()
 {
     serial[0] = 'S';
@@ -665,8 +665,8 @@ void generateSerial(bool force)
         // generate a serial number acc. the old style only for AVR's
 #if defined(ARDUINO_ARCH_AVR)
         generateRandomSerial();
-#elif defined(ARDUINO_ARCH_RP2040)
-        // For Pico always the UniqueID is used.
+#else
+        // For other boards always the UniqueID is used.
         readUniqueSerial();
         // If there is always a serial number acc. old style and the user
         // requests a new one, he will get the UniqueID and it's marked in the EEPROM
@@ -678,7 +678,7 @@ void generateSerial(bool force)
     }
 
     // A serial number according old style is already generated and saved to the eeprom
-    // For Pico this is kept for backwards compatibility
+    // For other boards this is kept for backwards compatibility
     if (MFeeprom.read_byte(MEM_OFFSET_SERIAL) == 'S' && MFeeprom.read_byte(MEM_OFFSET_SERIAL + 1) == 'N') {
         MFeeprom.read_block(MEM_OFFSET_SERIAL, serial, MEM_LEN_SERIAL);
         return;
@@ -689,8 +689,8 @@ void generateSerial(bool force)
     // or a uniqueID is already generated and saved to the eeprom
     // AVR's are forced to roll back to "old style" serial number
     generateRandomSerial();
-#elif defined(ARDUINO_ARCH_RP2040)
-    // Pico always uses the UniqueID
+#else
+    // other boards always uses the UniqueID
     readUniqueSerial();
 #endif
 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -671,7 +671,7 @@ void generateSerial(bool force)
         // If there is always a serial number acc. old style and the user
         // requests a new one, he will get the UniqueID and it's marked in the EEPROM
         if (MFeeprom.read_byte(MEM_OFFSET_SERIAL) == 'S' && MFeeprom.read_byte(MEM_OFFSET_SERIAL + 1) == 'N') {
-            MFeeprom.write_byte(MEM_OFFSET_CONFIG, 0x00);
+            MFeeprom.write_byte(MEM_OFFSET_SERIAL, 0x00);
         }
 #endif
         return;


### PR DESCRIPTION
## Description of changes

When introducing the UniqueID for the Pico the function to generate a new serial number, in this case according the AVR style, was kept. There is no reason to have this function as the UniqueID is always different between each Pico.
This is different to the AVR boards. They do not have a UniqueID and therefore a SN gets generated on first start up. Seldom the same SN can get generated like an already existing board. In this case the function to regenerate a SN is required.

The function to regenerate a SN for the Pico is deleted. But it is still checked if it was used before and a SN according the old style is used. In this case this SN will still be used to not get orphaned boards. If the user regenerates again a new SN, the UniqueID will be used and it gets markes in the EEPROM accordingly.
Furthermore setting the first byte of the config to `0x00` for new boards is deleted. This was discussed before but not implemented. It's deleted to be sure that a config get's never deleted from the FW itself.
