### PR TITLE
reduce write cycles to flash

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -189,6 +189,7 @@ void OnResetConfig()
 
 void OnSaveConfig()
 {
+    MFeeprom.commit();
     cmdMessenger.sendCmd(kConfigSaved, F("OK"));
 }
 
@@ -630,6 +631,7 @@ void generateRandomSerial()
         randomSerial >>= 4;
     }
     MFeeprom.write_block(MEM_OFFSET_SERIAL, serial, MEM_LEN_SERIAL);
+    MFeeprom.commit();
     cmdMessenger.sendCmd(kDebug, F("Serial number generated"));
 }
 
@@ -686,9 +688,11 @@ void generateSerial(bool force)
     readUniqueSerial();
     // mark this in the eeprom that a UniqueID is used on first start up for Pico's
     MFeeprom.write_block(MEM_OFFSET_SERIAL, "ID", 2);
+    MFeeprom.commit();
 #endif
     if (MFeeprom.read_byte(MEM_OFFSET_CONFIG) == 0xFF) {
         MFeeprom.write_block(MEM_OFFSET_CONFIG, 0x00);
+        MFeeprom.commit();
     }
 }
 

--- a/src/MF_Modules/MFEEPROM.cpp
+++ b/src/MF_Modules/MFEEPROM.cpp
@@ -12,7 +12,7 @@ MFEEPROM::MFEEPROM() {}
 
 void MFEEPROM::init(void)
 {
-#if defined(ARDUINO_ARCH_RP2040)
+#if !defined(ARDUINO_ARCH_AVR)
     EEPROM.begin(4096);
 #endif
     _eepromLength = EEPROM.length();

--- a/src/MF_Modules/MFEEPROM.cpp
+++ b/src/MF_Modules/MFEEPROM.cpp
@@ -33,9 +33,6 @@ bool MFEEPROM::write_byte(uint16_t adr, const uint8_t data)
 {
     if (adr >= _eepromLength) return false;
     EEPROM.write(adr, data);
-#if defined(ARDUINO_ARCH_RP2040)
-    EEPROM.commit();
-#endif
     return true;
 }
 

--- a/src/MF_Modules/MFEEPROM.h
+++ b/src/MF_Modules/MFEEPROM.h
@@ -19,6 +19,11 @@ public:
     uint16_t get_length(void);
     uint8_t read_byte(uint16_t adr);
     bool write_byte(uint16_t adr, const uint8_t data);
+    void commit() {
+#if !defined(ARDUINO_ARCH_AVR)
+        EEPROM.commit();
+#endif
+    }
 
     template <typename T>
     bool read_block(uint16_t adr, T &t)
@@ -44,9 +49,6 @@ public:
     {
         if (adr + sizeof(T) > _eepromLength) return false;
         EEPROM.put(adr, t);
-#if defined(ARDUINO_ARCH_RP2040)
-        EEPROM.commit();
-#endif
         return true;
     }
 
@@ -57,9 +59,6 @@ public:
         for (uint16_t i = 0; i < len; i++) {
             EEPROM.put(adr + i, t[i]);
         }
-#if defined(ARDUINO_ARCH_RP2040)
-        EEPROM.commit();
-#endif
         return true;
     }
 };


### PR DESCRIPTION
## Description of changes

The Raspberry Pico board has no internal or external EEPROM. Data which must be stored is using an EEPROM emulation. First all datas are moved to an internal buffer which can be commited to the flash memory.
For now each write command to the EEPROM emulation gets directly commited which leads to a number a flash writes.

This PR adds a function `commit()` which is only called when all parts of a config and the name is written to the buffer. This reduces the write cycles to the internal flash memory.

Fixes #331 