### PR TITLE
write eeprom or name if they are available even config is in flash

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -79,7 +79,6 @@ uint16_t       configLengthEEPROM              = 0;
 boolean        configActivated                 = false;
 uint16_t       pNameBuffer                     = 0; // pointer for nameBuffer during reading of config
 const uint16_t configLengthFlash               = sizeof(CustomDeviceConfig);
-// if config is in EEPROM, ensure upload a new config even if a config in flash is available
 
 void resetConfig();
 void readConfig();

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -80,7 +80,6 @@ boolean        configActivated                 = false;
 uint16_t       pNameBuffer                     = 0; // pointer for nameBuffer during reading of config
 const uint16_t configLengthFlash               = sizeof(CustomDeviceConfig);
 // if config is in EEPROM, ensure upload a new config even if a config in flash is available
-bool configEEPROMavailable = false;
 
 void resetConfig();
 void readConfig();
@@ -115,7 +114,6 @@ bool readconfigLengthEEPROM()
             return false;
         }
     }
-    configEEPROMavailable = true;
     return true;
 }
 
@@ -142,7 +140,7 @@ void OnSetConfig()
     char   *cfg    = cmdMessenger.readStringArg();
     uint8_t cfgLen = strlen(cfg);
 
-    if (configEEPROMavailable || !configStoredInFlash()) {
+    if (configStoredInEEPROM() || !configStoredInFlash()) {
         bool maxConfigLengthNotExceeded = configLengthEEPROM + cfgLen + 1 < MEM_LEN_CONFIG;
         if (maxConfigLengthNotExceeded) {
             // save the received config string including the terminatung NULL (+1) to EEPROM

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -733,6 +733,7 @@ void storeName()
     if (configStoredInEEPROM() || !configStoredInFlash()) {
         MFeeprom.write_byte(MEM_OFFSET_NAME, '#');
         MFeeprom.write_block(MEM_OFFSET_NAME + 1, name, MEM_LEN_NAME - 1);
+        MFeeprom.commit();
     }
 }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -733,7 +733,7 @@ void storeName()
     if (configStoredInEEPROM() || !configStoredInFlash()) {
         MFeeprom.write_byte(MEM_OFFSET_NAME, '#');
         MFeeprom.write_block(MEM_OFFSET_NAME + 1, name, MEM_LEN_NAME - 1);
-        MFeeprom.commit();
+        // MFeeprom.commit() is not required, name is always set before config
     }
 }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -140,17 +140,18 @@ void OnSetConfig()
     char   *cfg    = cmdMessenger.readStringArg();
     uint8_t cfgLen = strlen(cfg);
 
-    if (configStoredInEEPROM() || !configStoredInFlash()) {
+    if (!configStoredInFlash()) {
         bool maxConfigLengthNotExceeded = configLengthEEPROM + cfgLen + 1 < MEM_LEN_CONFIG;
         if (maxConfigLengthNotExceeded) {
             // save the received config string including the terminatung NULL (+1) to EEPROM
             MFeeprom.write_block(MEM_OFFSET_CONFIG + configLengthEEPROM, cfg, cfgLen + 1);
             configLengthEEPROM += cfgLen;
             cmdMessenger.sendCmd(kStatus, configLengthEEPROM);
-        } else
+        } else {
             // staus message to connector, failure on setting config
             // connector does not check for status = -1
             cmdMessenger.sendCmd(kStatus, -1);
+        }
 #ifdef DEBUG2CMDMESSENGER
         cmdMessenger.sendCmd(kDebug, F("Setting config end"));
 #endif
@@ -728,7 +729,7 @@ void OnGenNewSerial()
 // ************************************************************
 void storeName()
 {
-    if (configStoredInEEPROM() || !configStoredInFlash()) {
+    if (!configStoredInFlash()) {
         MFeeprom.write_byte(MEM_OFFSET_NAME, '#');
         MFeeprom.write_block(MEM_OFFSET_NAME + 1, name, MEM_LEN_NAME - 1);
         // MFeeprom.commit() is not required, name is always set before config
@@ -746,7 +747,7 @@ void restoreName()
 void OnSetName()
 {
     char *cfg = cmdMessenger.readStringArg();
-    if (configStoredInEEPROM() || !configStoredInFlash()) {
+    if (!configStoredInFlash()) {
         memcpy(name, cfg, MEM_LEN_NAME);
         storeName();
     }


### PR DESCRIPTION
## Description of changes

In addition to PR #327 fully backwards compatibility is now ensured.
Once a config is in EEPROM, this config can still be changed even a config is in flash.
Once a name is in EEPROM, this name can still be changed even a config is in flash.
If no name and no config is in EEPROM, name and config can not be changed anymore.