### PR TITLE
Fix compile error when using 2nd core for custom device

### DIFF
--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -123,7 +123,7 @@ namespace CustomDevice
         }
     }
 
-#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
+#if defined(USE_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     void stopUpdate2ndCore(bool stop)
     {
         // wait for 2nd core

--- a/src/MF_CustomDevice/CustomDevice.h
+++ b/src/MF_CustomDevice/CustomDevice.h
@@ -10,7 +10,7 @@ namespace CustomDevice
     void update();
     void OnSet();
     void PowerSave(bool state);
-#if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
+#if defined(USE_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)
     void stopUpdate2ndCore(bool stop);
 #endif
 }


### PR DESCRIPTION
## Description of changes

When compiling a custom device for a Raspberry Pico which uses the 2nd core, a compile error occurs.
This is due to a wrong check for `if defined(STEPPER_ON_2ND_CORE) && defined(ARDUINO_ARCH_RP2040)` as it must be checked for the custom device. This was accidentally implemted with PR #329.