### PR TITLE
support for multiple configuration lines on same display

### DIFF
--- a/src/MF_LCDDisplay/MFLCDDisplay.cpp
+++ b/src/MF_LCDDisplay/MFLCDDisplay.cpp
@@ -15,9 +15,17 @@ void MFLCDDisplay::display(const char *string)
 {
     if (!_initialized)
         return;
-    for (uint8_t line = 0; line != _lines; line++) {
-        _lcdDisplay.setCursor(0, line);
-        _lcdDisplay.writeString(&string[line * _cols], _cols);
+    
+    for (uint8_t line = 0; line != _lines; line++) 
+    {
+        for(uint8_t col = 0; col != _cols; col++)
+        {
+            _lcdDisplay.setCursor(col, line);
+            if(string[(line * _cols)+col] != '^')
+            {
+                _lcdDisplay.write(string[(line * _cols)+col]);
+            }
+        }
     }
 }
 

--- a/src/MF_LCDDisplay/MFLCDDisplay.cpp
+++ b/src/MF_LCDDisplay/MFLCDDisplay.cpp
@@ -20,7 +20,7 @@ void MFLCDDisplay::display(const char *string)
     {
         for(uint8_t col = 0; col != _cols; col++)
         {
-            if(string[(line * _cols)+col] != 28) //character 'FS' (File separator), surelly not used by users
+            if(string[(line * _cols)+col] != 28) //character 'FS' (File separator), surely not used by users
             {
                 _lcdDisplay.setCursor(col, line);
                 _lcdDisplay.write(string[(line * _cols)+col]);

--- a/src/MF_LCDDisplay/MFLCDDisplay.cpp
+++ b/src/MF_LCDDisplay/MFLCDDisplay.cpp
@@ -20,9 +20,9 @@ void MFLCDDisplay::display(const char *string)
     {
         for(uint8_t col = 0; col != _cols; col++)
         {
-            _lcdDisplay.setCursor(col, line);
-            if(string[(line * _cols)+col] != '^')
+            if(string[(line * _cols)+col] != 28) //character 'FS' (File separator), surelly not used by users
             {
+                _lcdDisplay.setCursor(col, line);
                 _lcdDisplay.write(string[(line * _cols)+col]);
             }
         }


### PR DESCRIPTION
## Description of changes

with this small change is possible to define multiple configuration lines on Mobiflight Connector in order to manage different parts of the display on different configuration lines. 
It's enough to put a "^" character in the display to skip that character from being shown on the display

Line 1
![image](https://github.com/user-attachments/assets/965e1136-4240-4daa-bee4-da10b6e22eeb)

Line 2
![image](https://github.com/user-attachments/assets/93b5cc0c-7833-4188-9415-bd6d0b9dfc51)

Result
![PXL_20240926_205308026](https://github.com/user-attachments/assets/55aa9a8c-6b43-4224-923a-4d188cecc9c2)


