### PR TITLE
Fixes analog read for pins A6 and A7

### DIFF
--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -18,6 +18,12 @@ void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity)
     _sensitivity = sensitivity;
     _pin         = pin;
     _name        = name;
+#if defined(ARDUINO_AVR_PROMICRO16)
+    if (_pin == 4)
+        _pin = A6;
+    else if (_pin == 6)
+        _pin = A7;
+#endif
     pinMode(_pin, INPUT_PULLUP); // set pin to input. Could use OUTPUT for analog, but shows the intention :-)
     // Fill averaging buffers with initial reading
     for (uint8_t i = 0; i < ADC_MAX_AVERAGE; i++) {

--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -19,6 +19,9 @@ void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity)
     _pin         = pin;
     _name        = name;
 #if defined(ARDUINO_AVR_PROMICRO16)
+    // ProMicro has a special pin assignment for analog pins
+    // therefore reading from A6 and A7 does not work
+    // via "digital" pins. See also pins_arduino.h
     if (_pin == 4)
         _pin = A6;
     else if (_pin == 6)


### PR DESCRIPTION
## Description of changes

ProMicro has some special pin mapping within pins_arduino.h through which analog pins `A6` and `A7` can not be adressed via there digital pin numbers. But Mobiflight does only use the digital pin numbers also for pins with analog readin function.
With this change it is checked if the digitla pin number is one of the two pin numbers and in this case a reampping is done so that the pin number fits to the required one.

Fixes #337 