### PR TITLE
Add power saving mode for outputsifter

### DIFF
--- a/src/MF_OutputShifter/MFOutputShifter.cpp
+++ b/src/MF_OutputShifter/MFOutputShifter.cpp
@@ -84,4 +84,17 @@ void MFOutputShifter::update()
     digitalWrite(_latchPin, HIGH);
 }
 
+void MFOutputShifter::powerSavingMode(bool state)
+{
+    if (state) {
+        digitalWrite(_latchPin, LOW);
+        for (uint8_t i = _moduleCount; i > 0; i--) {
+            shiftOut(_dataPin, _clockPin, MSBFIRST, 0xFF * MF_LOW);
+        }
+        digitalWrite(_latchPin, HIGH);
+    } else {
+        update();
+    }
+}
+
 // MFOutputShifter.cpp

--- a/src/MF_OutputShifter/MFOutputShifter.h
+++ b/src/MF_OutputShifter/MFOutputShifter.h
@@ -26,6 +26,7 @@ public:
     void detach();
     void clear();
     void update();
+    void powerSavingMode(bool state);
 
 private:
     uint8_t _latchPin;    // Latch pin

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -60,6 +60,13 @@ namespace OutputShifter
         int   value  = cmdMessenger.readInt16Arg();
         outputShifter[module].setPins(pins, value);
     }
+
+    void PowerSave(bool state)
+    {
+        for (uint8_t i = 0; i < outputShifterRegistered; ++i) {
+            outputShifter[i].powerSavingMode(state);
+        }
+    }
 } // namespace
 
 // OutputShifter.cpp

--- a/src/MF_OutputShifter/OutputShifter.h
+++ b/src/MF_OutputShifter/OutputShifter.h
@@ -12,6 +12,7 @@ namespace OutputShifter
     void Add(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin, uint8_t modules);
     void Clear();
     void OnSet();
+    void PowerSave(bool state);
 }
 
 // OutputShifter.h

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -123,6 +123,9 @@ void SetPowerSavingMode(bool state)
 #if MF_CUSTOMDEVICE_SUPPORT == 1
     CustomDevice::PowerSave(state);
 #endif
+#if MF_OUTPUT_SHIFTER_SUPPORT == 1
+    OutputShifter::PowerSave(state);
+#endif
 
 #ifdef DEBUG2CMDMESSENGER
     if (state)


### PR DESCRIPTION
## Description of changes

Power Saving mode is added for outputshifters.

Once the power saving mode should be entered, all pins of the outputshifters are set to `0` or `1` on case of reversed polarity.
When the power saving mode should be leaved, the actual status is shifted out and the pins are set to the original status.

Fixes #301 

