### PR TITLE
Power saving lcd

### DIFF
--- a/src/MF_LCDDisplay/LCDDisplay.cpp
+++ b/src/MF_LCDDisplay/LCDDisplay.cpp
@@ -53,6 +53,13 @@ namespace LCDDisplay
         cmdMessenger.unescape(output);
         lcd_I2C[address].display(output);
     }
+
+    void PowerSave(bool state)
+    {
+        for (uint8_t i = 0; i < lcd_12cRegistered; ++i) {
+            lcd_I2C[i].powerSavingMode(state);
+        }
+    }
 } // namespace
 
 // LCDDisplay.cpp

--- a/src/MF_LCDDisplay/LCDDisplay.h
+++ b/src/MF_LCDDisplay/LCDDisplay.h
@@ -13,6 +13,7 @@ namespace LCDDisplay
     void Add(uint8_t address = 0x24, uint8_t cols = 16, uint8_t lines = 2);
     void Clear();
     void OnSet();
+    void PowerSave(bool state);
 }
 
 // LCDDisplay.h

--- a/src/MF_LCDDisplay/MFLCDDisplay.cpp
+++ b/src/MF_LCDDisplay/MFLCDDisplay.cpp
@@ -42,10 +42,14 @@ void MFLCDDisplay::detach()
 
 void MFLCDDisplay::powerSavingMode(bool state)
 {
-    if (state)
+    if (state) {
         _lcdDisplay.noBacklight();
-    else
+        _lcdDisplay.noDisplay();
+    }
+    else {
         _lcdDisplay.backlight();
+        _lcdDisplay.display();
+    }
 }
 
 void MFLCDDisplay::test()

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -25,6 +25,9 @@
 #if MF_SERVO_SUPPORT == 1
 #include "Servos.h"
 #endif
+#if MF_LCD_SUPPORT == 1
+#include "LCDDisplay.h"
+#endif
 #if MF_OUTPUT_SHIFTER_SUPPORT == 1
 #include "OutputShifter.h"
 #endif
@@ -125,6 +128,9 @@ void SetPowerSavingMode(bool state)
 #endif
 #if MF_OUTPUT_SHIFTER_SUPPORT == 1
     OutputShifter::PowerSave(state);
+#endif
+#if MF_LCD_SUPPORT == 1
+    LCDDisplay::PowerSave(state);
 #endif
 
 #ifdef DEBUG2CMDMESSENGER


### PR DESCRIPTION
## Description of changes

Power Saving mode is added for LCD's.

Once the power saving mode should be entered, the backlight is switched **OFF** (not supported by all LCD types) and the display is switched **OFF** by using the library functions.
When the power saving mode should be leaved, the backlight is switched **ON** (not supported by all LCD types) and the display is switched **ON** by using the library functions.

Fixes #300  