### PR TITLE
set messenger buffersize to 90 for all boards like for the mega

### DIFF
--- a/_Boards/Atmel/Board_Nano/arduino_nano.board.json
+++ b/_Boards/Atmel/Board_Nano/arduino_nano.board.json
@@ -14,7 +14,7 @@
     "EEPROMSize": 286,
     "ExtraConnectionRetry": true,
     "ForceResetOnFirmwareUpdate": false,
-    "MessageSize": 64,
+    "MessageSize": 90,
     "TimeoutForFirmwareUpdate": 60000
   },
   "HardwareIds": [

--- a/_Boards/Atmel/Board_ProMicro/arduino_micro.board.json
+++ b/_Boards/Atmel/Board_ProMicro/arduino_micro.board.json
@@ -14,7 +14,7 @@
     "EEPROMSize": 440,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": true,
-    "MessageSize": 64
+    "MessageSize": 90
   },
   "HardwareIds": [
     "^VID_1B4F&PID_9206",

--- a/_Boards/Atmel/Board_Uno/arduino_uno.board.json
+++ b/_Boards/Atmel/Board_Uno/arduino_uno.board.json
@@ -14,7 +14,7 @@
     "EEPROMSize": 286,
     "ExtraConnectionRetry": true,
     "ForceResetOnFirmwareUpdate": false,
-    "MessageSize": 64
+    "MessageSize": 90
   },
   "HardwareIds": [
     "^VID_10C4&PID_EA60",

--- a/_Boards/RaspberryPi/Pico/raspberrypi_pico.board.json
+++ b/_Boards/RaspberryPi/Pico/raspberrypi_pico.board.json
@@ -11,7 +11,7 @@
     "EEPROMSize": 1496,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": true,
-    "MessageSize": 64
+    "MessageSize": 90
   },
   "HardwareIds": ["^VID_2E8A&PID_000A"],
   "Info": {


### PR DESCRIPTION
## Description of changes

For all boards the buffer for the command messenger is set to 96 bytes, accordingly the max. message size, which is defined in the board.json file, should be also for all boards 90 bytes. But only for the mega this is defined, for all other boards the max. buffer size is still 64 byte.

This PR defines the max. buffer size for the command messenger to 90 bytes for all boards like it is already for the mega.