### PR TITLE
Set FW version to 3.0

### DIFF
--- a/_Boards/Atmel/Board_Mega/arduino_mega.board.json
+++ b/_Boards/Atmel/Board_Mega/arduino_mega.board.json
@@ -37,7 +37,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "FirmwareBaseName": "mobiflight_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "2.5.2",
+    "LatestFirmwareVersion": "3.0",
     "FriendlyName": "Arduino Mega 2560",
     "MobiFlightType": "MobiFlight Mega",
     "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex"

--- a/_Boards/Atmel/Board_Mega/arduino_mega.board.json
+++ b/_Boards/Atmel/Board_Mega/arduino_mega.board.json
@@ -37,7 +37,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "FirmwareBaseName": "mobiflight_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "3.0",
+    "LatestFirmwareVersion": "3.0.0",
     "FriendlyName": "Arduino Mega 2560",
     "MobiFlightType": "MobiFlight Mega",
     "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex"

--- a/_Boards/Atmel/Board_Nano/arduino_nano.board.json
+++ b/_Boards/Atmel/Board_Nano/arduino_nano.board.json
@@ -33,7 +33,7 @@
     "FirmwareBaseName": "mobiflight_nano",
     "FirmwareExtension": "hex",
     "FriendlyName": "Arduino Nano",
-    "LatestFirmwareVersion": "2.5.2",
+    "LatestFirmwareVersion": "3.0",
     "MobiFlightType": "MobiFlight Nano",
     "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
   },

--- a/_Boards/Atmel/Board_Nano/arduino_nano.board.json
+++ b/_Boards/Atmel/Board_Nano/arduino_nano.board.json
@@ -33,7 +33,7 @@
     "FirmwareBaseName": "mobiflight_nano",
     "FirmwareExtension": "hex",
     "FriendlyName": "Arduino Nano",
-    "LatestFirmwareVersion": "3.0",
+    "LatestFirmwareVersion": "3.0.0",
     "MobiFlightType": "MobiFlight Nano",
     "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
   },

--- a/_Boards/Atmel/Board_ProMicro/arduino_micro.board.json
+++ b/_Boards/Atmel/Board_ProMicro/arduino_micro.board.json
@@ -27,7 +27,7 @@
     "FirmwareBaseName": "mobiflight_micro",
     "FirmwareExtension": "hex",
     "FriendlyName": "Arduino Pro Micro",
-    "LatestFirmwareVersion": "3.0",
+    "LatestFirmwareVersion": "3.0.0",
     "MobiFlightType": "MobiFlight Micro",
     "ResetFirmwareFile": "reset.arduino_promicro_1_0_2.hex"
   },

--- a/_Boards/Atmel/Board_ProMicro/arduino_micro.board.json
+++ b/_Boards/Atmel/Board_ProMicro/arduino_micro.board.json
@@ -27,7 +27,7 @@
     "FirmwareBaseName": "mobiflight_micro",
     "FirmwareExtension": "hex",
     "FriendlyName": "Arduino Pro Micro",
-    "LatestFirmwareVersion": "2.5.2",
+    "LatestFirmwareVersion": "3.0",
     "MobiFlightType": "MobiFlight Micro",
     "ResetFirmwareFile": "reset.arduino_promicro_1_0_2.hex"
   },

--- a/_Boards/Atmel/Board_Uno/arduino_uno.board.json
+++ b/_Boards/Atmel/Board_Uno/arduino_uno.board.json
@@ -32,7 +32,7 @@
     "FriendlyName": "Arduino Uno",
     "FirmwareBaseName": "mobiflight_uno",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "3.0",
+    "LatestFirmwareVersion": "3.0.0",
     "MobiFlightType": "MobiFlight Uno",
     "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
   },

--- a/_Boards/Atmel/Board_Uno/arduino_uno.board.json
+++ b/_Boards/Atmel/Board_Uno/arduino_uno.board.json
@@ -32,7 +32,7 @@
     "FriendlyName": "Arduino Uno",
     "FirmwareBaseName": "mobiflight_uno",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "2.5.2",
+    "LatestFirmwareVersion": "3.0",
     "MobiFlightType": "MobiFlight Uno",
     "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
   },

--- a/_Boards/RaspberryPi/Pico/raspberrypi_pico.board.json
+++ b/_Boards/RaspberryPi/Pico/raspberrypi_pico.board.json
@@ -20,7 +20,7 @@
     "FirmwareBaseName": "mobiflight_raspberrypico",
     "FirmwareExtension": "uf2",
     "FriendlyName": "Raspberry Pico",
-    "LatestFirmwareVersion": "3.0",
+    "LatestFirmwareVersion": "3.0.0",
     "MobiFlightType": "MobiFlight RaspiPico",
     "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2"
   },

--- a/_Boards/RaspberryPi/Pico/raspberrypi_pico.board.json
+++ b/_Boards/RaspberryPi/Pico/raspberrypi_pico.board.json
@@ -20,7 +20,7 @@
     "FirmwareBaseName": "mobiflight_raspberrypico",
     "FirmwareExtension": "uf2",
     "FriendlyName": "Raspberry Pico",
-    "LatestFirmwareVersion": "2.5.2",
+    "LatestFirmwareVersion": "3.0",
     "MobiFlightType": "MobiFlight RaspiPico",
     "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2"
   },


### PR DESCRIPTION
## Description of changes

Next FW version will be 3.0 instead of 2.5.2. This is changed in all board.json files.
It overrules #335 (already merged) where it was intended to have version 2.5.2.
