### PR TITLE
Improve connection

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -79,6 +79,7 @@ uint16_t       configLengthEEPROM              = 0;
 boolean        configActivated                 = false;
 uint16_t       pNameBuffer                     = 0; // pointer for nameBuffer during reading of config
 const uint16_t configLengthFlash               = sizeof(CustomDeviceConfig);
+bool boardReady                                = false;
 
 void resetConfig();
 void readConfig();
@@ -92,6 +93,11 @@ bool configStoredInFlash()
 bool configStoredInEEPROM()
 {
     return configLengthEEPROM > 0;
+}
+
+bool getBoardReady()
+{
+    return boardReady;
 }
 
 // ************************************************************
@@ -605,6 +611,7 @@ void OnGetConfig()
         }
     }
     cmdMessenger.sendCmdEnd();
+    boardReady = true;
 }
 
 void OnGetInfo()

--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -17,6 +17,8 @@ namespace Analog
 
     void handlerOnAnalogChange(int value, const char *name)
     {
+        if (!getBoardReady())
+            return;
         cmdMessenger.sendCmdStart(kAnalogChange);
         cmdMessenger.sendCmdArg(name);
         cmdMessenger.sendCmdArg(value);

--- a/src/MF_Button/Button.cpp
+++ b/src/MF_Button/Button.cpp
@@ -16,6 +16,8 @@ namespace Button
 
     void handlerButtonOnChange(uint8_t eventId, const char *name)
     {
+        if (!getBoardReady())
+            return;
         cmdMessenger.sendCmdStart(kButtonChange);
         cmdMessenger.sendCmdArg(name);
         cmdMessenger.sendCmdArg(eventId);

--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -18,6 +18,8 @@ namespace DigInMux
 
     void handlerOnDigInMux(uint8_t eventId, uint8_t channel, const char *name)
     {
+        if (!getBoardReady())
+            return;
         cmdMessenger.sendCmdStart(kDigInMuxChange);
         cmdMessenger.sendCmdArg(name);
         cmdMessenger.sendCmdArg(channel);

--- a/src/MF_Encoder/Encoder.cpp
+++ b/src/MF_Encoder/Encoder.cpp
@@ -16,6 +16,8 @@ namespace Encoder
 
     void       handlerOnEncoder(uint8_t eventId, const char *name)
     {
+        if (!getBoardReady())
+            return;
         cmdMessenger.sendCmdStart(kEncoderChange);
         cmdMessenger.sendCmdArg(name);
         cmdMessenger.sendCmdArg(eventId);

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -16,6 +16,8 @@ namespace InputShifter
 
     void handlerInputShifterOnChange(uint8_t eventId, uint8_t pin, const char *name)
     {
+        if (!getBoardReady())
+            return;
         cmdMessenger.sendCmdStart(kInputShifterChange);
         cmdMessenger.sendCmdArg(name);
         cmdMessenger.sendCmdArg(pin);

--- a/src/config.h
+++ b/src/config.h
@@ -40,5 +40,6 @@ void OnGetInfo(void);
 void OnGenNewSerial(void);
 void OnSetName(void);
 void restoreName(void);
+bool getBoardReady();
 
 // config.h


### PR DESCRIPTION
## Description of changes

From time to time it happens that a board is not recognized from the connector. For now the reason is unclear.

Some times it happens, that a board sends messages from inputs even that they are initialized on their actual status. It might be that these messages are send when the connector expects the board info and therefore these messages are interpreted as info. As they are totally diferent to the board info message, the connector will not recognize this board.

On start up from a board the config gets loaded and status changes of input devices get send afterwords. With this change an additional flag is added that suppress messages from input devices until the config was read from the connector. Hopefully this will fix the connection problems which occur sometimes.
