### PR TITLE
deviceID gets sent from the connector instead of pin number

### DIFF
--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -46,16 +46,10 @@ namespace Output
     void OnSet()
     {
         // Read led state argument, interpret string as boolean
-        int pin   = cmdMessenger.readInt16Arg();
+        int output   = cmdMessenger.readInt16Arg();
         int state = cmdMessenger.readInt16Arg();
-    
-        // Set led
-        if (state == 0xFF)
-            digitalWrite(pin, MF_HIGH);
-        else if (state == 0x00)
-            digitalWrite(pin, MF_LOW);
-        else
-            analogWrite(pin, state);
+
+        outputs[output].set(state);
     }
 
     void PowerSave(bool state)


### PR DESCRIPTION
## Description of changes

Once the PR [1886](https://github.com/MobiFlight/MobiFlight-Connector/pull/1886) from the connector is merged the command for setting an output will be slightly different. Instead of sending a pin number the deviceID is send like for all other devices. This is for harmaonization and possible future extensions.

Fixes #345