### PR TITLE
init analog input w/o pullup

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -514,10 +514,14 @@ void readConfigFromMemory(bool configFromFlash)
 #endif
 
 #if MF_ANALOG_SUPPORT == 1
+        case kTypeAnalogInputDeprecated:
         case kTypeAnalogInput:
             params[0] = readUint(&addrMem, configFromFlash);                              // pin number
             params[1] = readUint(&addrMem, configFromFlash);                              // sensitivity
-            Analog::Add(params[0], &nameBuffer[pNameBuffer], params[1]);                  // MUST be before readName because readName returns the pointer for the NEXT Name
+            if (command == kTypeAnalogInputDeprecated)
+                Analog::Add(params[0], &nameBuffer[pNameBuffer], params[1], true);        // MUST be before readName because readName returns the pointer for the NEXT Name
+            else
+                Analog::Add(params[0], &nameBuffer[pNameBuffer], params[1], false);       // MUST be before readName because readName returns the pointer for the NEXT Name
             copy_success = readName(&addrMem, nameBuffer, &pNameBuffer, configFromFlash); // copy the NULL terminated name to to nameBuffer and set to next free memory location
                                                                                           //    copy_success = readEndCommand(&addrMem, ':');       // once the nameBuffer is not required anymore uncomment this line and delete the line before
             break;

--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -34,13 +34,13 @@ namespace Analog
         return true;
     }
 
-    void Add(uint8_t pin, char const *name, uint8_t sensitivity)
+    void Add(uint8_t pin, char const *name, uint8_t sensitivity, bool deprecated)
     {
         if (analogRegistered == maxAnalogIn)
             return;
 
         analog[analogRegistered] = MFAnalog();
-        analog[analogRegistered].attach(pin, name, sensitivity);
+        analog[analogRegistered].attach(pin, name, sensitivity, deprecated);
         MFAnalog::attachHandler(handlerOnAnalogChange);
         analogRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_Analog/Analog.h
+++ b/src/MF_Analog/Analog.h
@@ -10,7 +10,7 @@
 namespace Analog
 {
     bool setupArray(uint16_t count);
-    void Add(uint8_t pin, char const *name = "AnalogInput", uint8_t sensitivity = 3);
+    void Add(uint8_t pin, char const *name = "AnalogInput", uint8_t sensitivity = 3, bool deprecated = true);
     void Clear();
     void read();
     void readAverage();

--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -27,7 +27,6 @@ void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity)
     else if (_pin == 6)
         _pin = A7;
 #endif
-    pinMode(_pin, INPUT_PULLUP); // set pin to input. Could use OUTPUT for analog, but shows the intention :-)
     // Fill averaging buffers with initial reading
     for (uint8_t i = 0; i < ADC_MAX_AVERAGE; i++) {
         readBuffer();

--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -13,7 +13,7 @@ MFAnalog::MFAnalog()
     _initialized = false;
 }
 
-void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity)
+void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity, bool deprecated)
 {
     _sensitivity = sensitivity;
     _pin         = pin;
@@ -27,6 +27,10 @@ void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity)
     else if (_pin == 6)
         _pin = A7;
 #endif
+    // enabling PullUp makes a nonlinear behaviour if pot is used
+    if (deprecated)
+        pinMode(_pin, INPUT_PULLUP);
+        
     // Fill averaging buffers with initial reading
     for (uint8_t i = 0; i < ADC_MAX_AVERAGE; i++) {
         readBuffer();

--- a/src/MF_Analog/MFAnalog.h
+++ b/src/MF_Analog/MFAnalog.h
@@ -26,7 +26,7 @@ class MFAnalog
 public:
     MFAnalog();
     static void attachHandler(analogEvent handler);
-    void        attach(uint8_t pin, const char *name, uint8_t sensitivity);
+    void        attach(uint8_t pin, const char *name, uint8_t sensitivity, bool deprecated);
     void        update();
     void        retrigger();
     void        readBuffer();

--- a/src/config.h
+++ b/src/config.h
@@ -18,13 +18,14 @@ enum {
     kTypeEncoder,              // 8
     kTypeStepperDeprecated2,   // 9 (keep for backwards compatibility, stepper type with auto zero support if btnPin is > 0)
     kTypeOutputShifter,        // 10 Shift register support (example: 74HC595, TLC592X)
-    kTypeAnalogInput,          // 11 Analog Device with 1 pin
+    kTypeAnalogInputDeprecated,// 11 Analog Device with 1 pin
     kTypeInputShifter,         // 12 Input shift register support (example: 74HC165)
     kTypeMuxDriver,            // 13 Multiplexer selector support (generates select outputs)
     kTypeDigInMux,             // 14 Digital input multiplexer support (example: 74HCT4067, 74HCT4051)
     kTypeStepper,              // 15 new stepper type with settings for backlash and deactivate output
     kTypeLedSegmentMulti,      // 16 new led segment with MAX7219 and TM1637 support
     kTypeCustomDevice,         // 17 Custom Device
+    kTypeAnalogInput,          // 18 Analog Device without PullUp enabled
     kTypeMax                   // if new device types are added, this MUST be before this one!
 };
 


### PR DESCRIPTION
## Description of changes

In the actual code a pin for reading analog values is initialized with pullups enabled. When connecting a potentiometer to the pin this internal resistor is always parallel to the "upper" part of the potentiometer. The internal pullup resistor is ~35kOhm.
This results in a non linear behaviour of the potentiometer. For a 10kOhm potentiometer the deviation is max. 4% at 70% position, this increases for higher values of the potentiometer.
Examples are:
50kOhm: 16% deviation at 70% position
100kOhm: 26% deviation at 70% position
500kOhm: 56% deviation at 80% position

The code change is not to use the internal pullup resistor. Also setting the `pinMode()` is not required as this is done during the `analogRead()` function.

Fixes #347 
