### PR TITLE
Set version in json files using firmware version information

### DIFF
--- a/_Boards/Atmel/Board_Mega/arduino_mega.board.json
+++ b/_Boards/Atmel/Board_Mega/arduino_mega.board.json
@@ -37,7 +37,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "FirmwareBaseName": "mobiflight_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "3.0.0",
+    "LatestFirmwareVersion": "0.0.1",
     "FriendlyName": "Arduino Mega 2560",
     "MobiFlightType": "MobiFlight Mega",
     "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex"

--- a/_Boards/Atmel/Board_Nano/arduino_nano.board.json
+++ b/_Boards/Atmel/Board_Nano/arduino_nano.board.json
@@ -33,7 +33,7 @@
     "FirmwareBaseName": "mobiflight_nano",
     "FirmwareExtension": "hex",
     "FriendlyName": "Arduino Nano",
-    "LatestFirmwareVersion": "3.0.0",
+    "LatestFirmwareVersion": "0.0.1",
     "MobiFlightType": "MobiFlight Nano",
     "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
   },

--- a/_Boards/Atmel/Board_ProMicro/arduino_micro.board.json
+++ b/_Boards/Atmel/Board_ProMicro/arduino_micro.board.json
@@ -27,7 +27,7 @@
     "FirmwareBaseName": "mobiflight_micro",
     "FirmwareExtension": "hex",
     "FriendlyName": "Arduino Pro Micro",
-    "LatestFirmwareVersion": "3.0.0",
+    "LatestFirmwareVersion": "0.0.1",
     "MobiFlightType": "MobiFlight Micro",
     "ResetFirmwareFile": "reset.arduino_promicro_1_0_2.hex"
   },

--- a/_Boards/Atmel/Board_Uno/arduino_uno.board.json
+++ b/_Boards/Atmel/Board_Uno/arduino_uno.board.json
@@ -32,7 +32,7 @@
     "FriendlyName": "Arduino Uno",
     "FirmwareBaseName": "mobiflight_uno",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "3.0.0",
+    "LatestFirmwareVersion": "0.0.1",
     "MobiFlightType": "MobiFlight Uno",
     "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
   },

--- a/_Boards/RaspberryPi/Pico/raspberrypi_pico.board.json
+++ b/_Boards/RaspberryPi/Pico/raspberrypi_pico.board.json
@@ -20,7 +20,7 @@
     "FirmwareBaseName": "mobiflight_raspberrypico",
     "FirmwareExtension": "uf2",
     "FriendlyName": "Raspberry Pico",
-    "LatestFirmwareVersion": "3.0.0",
+    "LatestFirmwareVersion": "0.0.1",
     "MobiFlightType": "MobiFlight RaspiPico",
     "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2"
   },

--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -1,5 +1,6 @@
 Import("env")
 import os, zipfile, shutil
+import fileinput
 from pathlib import Path
 
 # Get the version number from the build environment.
@@ -38,6 +39,13 @@ def copy_fw_files (source, target, env):
     file_extension = '.json'
     copy_files_by_extension(board_folder, build_path_json, file_extension)
 
+    # set FW version within boad.json files
+    replacements = {
+        "0.0.1": firmware_version
+    }
+    for file_path in build_path_json.rglob("*.json"):
+        replace_in_file(file_path, replacements)
+
     # Create ZIP file and add files from distrubution folder
     zip_file_path = distrubution_path + '/' + zip_file_name + '_' + firmware_version + '.zip'
     createZIP(build_path, zip_file_path, zip_file_name)
@@ -63,6 +71,18 @@ def createZIP(original_folder_path, zip_file_path, new_folder_name):
                 new_path = os.path.join(new_folder_name, os.path.relpath(os.path.join(root, file), original_folder_path))
                 # Add the file to the ZIP file
                 zipf.write(os.path.join(root, file), new_path)
+
+
+def replace_in_file(file_path, replacements):
+    """Replace all keys in `replacements` with their values in the given file."""
+    with open(file_path, "r", encoding="utf-8") as file:
+        content = file.read()
+
+    for old, new in replacements.items():
+        content = content.replace(old, new)
+
+    with open(file_path, "w", encoding="utf-8") as file:
+        file.write(content)
 
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex", copy_fw_files)

--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -11,10 +11,10 @@ firmware_version = firmware_version.lstrip("v")
 firmware_version = firmware_version.strip(".")
 
 zip_file_name = 'Mobiflight-Connector'
-build_path = Path()'./_build')
-build_path_fw = Path(build_path + '/firmware')
-build_path_json = Path(build_path + '/Boards')
-distrubution_path = Path('./_dist')
+build_path = Path('./_build')
+build_path_fw = build_path / 'firmware'
+build_path_json = build_path / 'Boards'
+distrubution_path = './_dist'
 board_folder = ['./_Boards/Atmel', './_Boards/RaspberryPi']
 
 def copy_fw_files (source, target, env):

--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -11,10 +11,10 @@ firmware_version = firmware_version.lstrip("v")
 firmware_version = firmware_version.strip(".")
 
 zip_file_name = 'Mobiflight-Connector'
-build_path = './_build'
-build_path_fw = build_path + '/firmware'
-build_path_json = build_path + '/Boards'
-distrubution_path = './_dist'
+build_path = Path()'./_build')
+build_path_fw = Path(build_path + '/firmware')
+build_path_json = Path(build_path + '/Boards')
+distrubution_path = Path('./_dist')
 board_folder = ['./_Boards/Atmel', './_Boards/RaspberryPi']
 
 def copy_fw_files (source, target, env):


### PR DESCRIPTION
## Description of changes

The python script `copy_fw_files.py` is extended to set `"LatestFirmwareVersion"` to the release tag during build process on github.
In all board.json files the `"LatestFirmwareVersion"` is set to `0.0.1` which get be replaced.

Fixes #350 
