### PR TITLE
Fix Analog Read not working

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -363,7 +363,7 @@ void InitArrays(uint8_t *numberDevices)
         sendFailureMessage("LCD");
 #endif
 #if MF_ANALOG_SUPPORT == 1
-    if (!Analog::setupArray(numberDevices[kTypeAnalogInput]))
+    if (!Analog::setupArray(numberDevices[kTypeAnalogInput] + numberDevices[kTypeAnalogInputDeprecated]))
         sendFailureMessage("AnalogIn");
 #endif
 #if MF_OUTPUT_SHIFTER_SUPPORT == 1


### PR DESCRIPTION
## Description of changes

With FW version 3.0.0 analog read is not working anymore.
In this version a new deviceID for analog devices was introduced. This new analog device does not enable the PullUp's for the configured pins to get a linear read in.
During reading the config from flash the number of devices per type is calculated to define the array size for these devices. For devices with deprecated ID's also these one have to be considered. This was not implemented. So only new analog device types are considered, but as the connector does not support this type yet, the number of analog devices is always zero. While adding a device it's checked if the calculatd number get's exceeded. If so, no device gets added.

Fixes #356 