### PR TITLE
Update LCD library to v1.1.5

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@
 [env]
 lib_deps = 
 	waspinator/AccelStepper @ 1.61
-	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4
+	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.5
 	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
 custom_lib_deps_Atmel =
 	arduino-libraries/Servo @ 1.1.8


### PR DESCRIPTION
Setting the cursor for 16x4 displays does not work.
Calculation the position for writing the text into the internal RAM is faulty as a fixed offset for the 3rd and 4th row is used.
Instead the number of columns must be considered. This is fixed in version v1.1.5 from the LCD library.
See also https://github.com/MobiFlight/LiquidCrystal_I2C/pull/3.

For successfull running the workflow the new release must be available which is for now outstanding.

Fixes #358 
