### PR TITLE
New version of CMDmessenger library

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@
 lib_deps = 
 	waspinator/AccelStepper @ 1.61
 	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4
-	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.1
+	https://github.com/MobiFlight/Arduino-CmdMessenger#4.2.2
 custom_lib_deps_Atmel =
 	arduino-libraries/Servo @ 1.1.8
 custom_lib_deps_Pico =


### PR DESCRIPTION
## Description of changes

New version of CMDmessenger library without `PID` and `Adafruit-MAX31855` library link.
