### PR TITLE
Fix powersaving mode

### DIFF
--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -92,6 +92,14 @@ void PowerSavingWrapper_OutputShifter_OnSet()
 }
 #endif
 
+#ifdef MF_SERVO_SUPPORT
+void PowerSavingWrapper_Servo_OnSet()
+{
+    trackCommand();
+    Servos::OnSet();
+}
+#endif
+
 #ifdef MF_CUSTOMDEVICE_SUPPORT
 void PowerSavingWrapper_CustomDevice_OnSet()
 {
@@ -124,7 +132,7 @@ void attachCommandCallbacks()
 #endif
 
 #ifdef MF_SERVO_SUPPORT
-    cmdMessenger.attach(kSetServo, Servos::OnSet);
+    cmdMessenger.attach(kSetServo, PowerSavingWrapper_Servo_OnSet);
 #endif
 
     cmdMessenger.attach(kGetInfo, OnGetInfo);

--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -64,7 +64,7 @@ void PowerSavingWrapper_LedSegmentModule_OnSet()
 void PowerSavingWrapper_LedSegmentSingleSegment_OnSet()
 {
     trackCommand();
-    LedSegment::OnSetModule();
+    LedSegment::OnSetModuleSingleSegment();
 }
 #endif
 

--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -44,6 +44,63 @@ void OnSetPowerSavingMode();
 void OnTrigger();
 void OnUnknownCommand();
 
+void trackCommand()
+{
+    lastCommand = millis();
+}
+
+void PowerSavingWrapper_Output_OnSet()
+{
+    trackCommand();
+    Output::OnSet();
+}
+
+#ifdef MF_SEGMENT_SUPPORT
+void PowerSavingWrapper_LedSegmentModule_OnSet()
+{
+    trackCommand();
+    LedSegment::OnSetModule();
+}
+void PowerSavingWrapper_LedSegmentSingleSegment_OnSet()
+{
+    trackCommand();
+    LedSegment::OnSetModule();
+}
+#endif
+
+#ifdef MF_STEPPER_SUPPORT
+void PowerSavingWrapper_Stepper_OnSet()
+{
+    trackCommand();
+    Stepper::OnSet();
+}
+#endif
+
+#ifdef MF_LCD_SUPPORT
+void PowerSavingWrapper_LCD_OnSet()
+{
+    trackCommand();
+    LCDDisplay::OnSet();
+}
+#endif
+
+#ifdef MF_OUTPUT_SHIFTER_SUPPORT
+void PowerSavingWrapper_OutputShifter_OnSet()
+{
+    trackCommand();
+    OutputShifter::OnSet();
+}
+#endif
+
+#ifdef MF_CUSTOMDEVICE_SUPPORT
+void PowerSavingWrapper_CustomDevice_OnSet()
+{
+    trackCommand();
+    CustomDevice::OnSet();
+}
+#endif
+
+
 // Callbacks define on which received commands we take action
 void attachCommandCallbacks()
 {
@@ -52,15 +109,15 @@ void attachCommandCallbacks()
 
 #ifdef MF_SEGMENT_SUPPORT
     cmdMessenger.attach(kInitModule, LedSegment::OnInitModule);
-    cmdMessenger.attach(kSetModule, LedSegment::OnSetModule);
+    cmdMessenger.attach(kSetModule, PowerSavingWrapper_LedSegmentModule_OnSet);
     cmdMessenger.attach(kSetModuleBrightness, LedSegment::OnSetModuleBrightness);
-    cmdMessenger.attach(kSetModuleSingleSegment, LedSegment::OnSetModuleSingleSegment);
+    cmdMessenger.attach(kSetModuleSingleSegment, PowerSavingWrapper_LedSegmentSingleSegment_OnSet);
 #endif
 
     cmdMessenger.attach(kSetPin, Output::OnSet);
 
 #ifdef MF_STEPPER_SUPPORT
-    cmdMessenger.attach(kSetStepper, Stepper::OnSet);
+    cmdMessenger.attach(kSetStepper, PowerSavingWrapper_Stepper_OnSet);
     cmdMessenger.attach(kResetStepper, Stepper::OnReset);
     cmdMessenger.attach(kSetZeroStepper, Stepper::OnSetZero);
     cmdMessenger.attach(kSetStepperSpeedAccel, Stepper::OnSetSpeedAccel);
@@ -82,11 +139,11 @@ void attachCommandCallbacks()
     cmdMessenger.attach(kSetPowerSavingMode, OnSetPowerSavingMode);
 
 #ifdef MF_LCD_SUPPORT
-    cmdMessenger.attach(kSetLcdDisplayI2C, LCDDisplay::OnSet);
+    cmdMessenger.attach(kSetLcdDisplayI2C, PowerSavingWrapper_LCD_OnSet);
 #endif
 
 #ifdef MF_OUTPUT_SHIFTER_SUPPORT
-    cmdMessenger.attach(kSetShiftRegisterPins, OutputShifter::OnSet);
+    cmdMessenger.attach(kSetShiftRegisterPins, PowerSavingWrapper_OutputShifter_OnSet);
 #endif
 
 #ifdef MF_CUSTOMDEVICE_SUPPORT


### PR DESCRIPTION
## Description of changes

If a message to an output device is send, this message should also reset the timer for entering the power safe mode.
Espacially in Test Mode keep alive messages are not send, so output devices are entering the power safe mode even output messages are generated.

Messages to output devices will now reset the timer for entering the Power Safe Mode.
A wrapper function for each output device is added which is called when a message is received.
This function resets the timer for entering the output device and calls the `OnSet()` function accordingly.

Fixes #361 