### PR TITLE
Send command 'kRetriggerDone' after retrigger of all inputs

### DIFF
--- a/src/CommandMessenger.cpp
+++ b/src/CommandMessenger.cpp
@@ -147,6 +147,7 @@ void OnTrigger()
 #ifdef MF_ANALOG_SUPPORT
     Analog::OnTrigger();
 #endif
+    cmdMessenger.sendCmd(kRetriggerDone);
 }
 
 // commandmessenger.cpp

--- a/src/commandmessenger.h
+++ b/src/commandmessenger.h
@@ -47,6 +47,7 @@ enum {
     kSetStepperSpeedAccel,   // 31
     kSetCustomDevice,        // 32
     kSetModuleSingleSegment, // 33
+    kRetriggerDone,          // 34
     kDebug = 0xFF            // 255
 };
 


### PR DESCRIPTION
## Description of changes

A command gets send when all retrigger messages has been send.
This avoids lost messages from the connector if quite a lot events from the FW are send due to a big configuration.

Fixes #363 