### PR TITLE
Fix adding Zip Files to PRs

### DIFF
--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   artifacts-url-comments:
     name: Add artifact links to pull request
-    runs-on: windows-2019
+    runs-on: windows-2025
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: tonyhallett/artifacts-url-comments@v1.1.0


### PR DESCRIPTION
## Description of changes

Adding Zip files to PRs must run on Windows Server 2025 as version 2019 is outdated.

Changed version 2019 to 2025.

Fixes #365 
