### PR TITLE
Wrong zip file name was attached to PRs and Release

### DIFF
--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -15,5 +15,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prefix: "Board and firmware folder for this pull request:"
-          format: "[Mobiflight-Connector.zip]({url})"
+          format: "[Mobiflight-Firmware.zip]({url})"
           addTo: pull

--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -10,7 +10,7 @@ if firmware_version == "":
 firmware_version = firmware_version.lstrip("v")
 firmware_version = firmware_version.strip(".")
 
-zip_file_name = 'Mobiflight-Connector'
+zip_file_name = 'Mobiflight-Firmware'
 build_path = Path('./_build')
 build_path_fw = build_path / 'firmware'
 build_path_json = build_path / 'Boards'


### PR DESCRIPTION
## Description of changes

Zip file name was `Mobiflight-Connector" which was attached to Pull Requests and Release files.
This is fixed now, Zip file name is `MobiFlight-Firmware`.

Fixes #370 