### PR TITLE
Enable pullup on inputshifter data pin

### DIFF
--- a/src/MF_InputShifter/MFInputShifter.cpp
+++ b/src/MF_InputShifter/MFInputShifter.cpp
@@ -26,7 +26,7 @@ bool MFInputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin,
 
     pinMode(_latchPin, OUTPUT);
     pinMode(_clockPin, OUTPUT);
-    pinMode(_dataPin, INPUT);
+    pinMode(_dataPin, INPUT_PULLUP);
 
     if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
         return false;


### PR DESCRIPTION
## Description of changes

Enable PullUp for Data In pin for InputShifter.

Not connected InputShifter but defined on the board leads to multiple messages to the connector due to floating pin if PullUp is **not** enabled. This is fixed with this PR.

Fixes #372
