### PR TITLE
Improved memory allocation for Picos

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -175,7 +175,7 @@ build_flags =
 	'-DMOBIFLIGHT_NAME="MobiFlight RaspiPico"'
 	-DMEMLEN_CONFIG=1496					; max. size for config which wil be stored in EEPROM
 	-DMEMLEN_NAMES_BUFFER=1000				; max. size for configBuffer, contains only names from inputs
-	-DMF_MAX_DEVICEMEM=2000					; max. memory size for devices
+	-DMF_MAX_DEVICEMEM=1000					; max. memory size for devices
 	-I./_Boards/RaspberryPi/Pico
 build_unflags =
 	;-DMF_STEPPER_SUPPORT					; this is just an example how to deactivate a device

--- a/platformio.ini
+++ b/platformio.ini
@@ -175,7 +175,7 @@ build_flags =
 	'-DMOBIFLIGHT_NAME="MobiFlight RaspiPico"'
 	-DMEMLEN_CONFIG=1496					; max. size for config which wil be stored in EEPROM
 	-DMEMLEN_NAMES_BUFFER=1000				; max. size for configBuffer, contains only names from inputs
-	-DMF_MAX_DEVICEMEM=1000					; max. memory size for devices
+	-DMF_MAX_DEVICEMEM=4000					; max. memory size for devices
 	-I./_Boards/RaspberryPi/Pico
 build_unflags =
 	;-DMF_STEPPER_SUPPORT					; this is just an example how to deactivate a device

--- a/platformio.ini
+++ b/platformio.ini
@@ -175,7 +175,7 @@ build_flags =
 	'-DMOBIFLIGHT_NAME="MobiFlight RaspiPico"'
 	-DMEMLEN_CONFIG=1496					; max. size for config which wil be stored in EEPROM
 	-DMEMLEN_NAMES_BUFFER=1000				; max. size for configBuffer, contains only names from inputs
-	-DMF_MAX_DEVICEMEM=4000					; max. memory size for devices
+	-DMF_MAX_DEVICEMEM=2000					; max. memory size for devices
 	-I./_Boards/RaspberryPi/Pico
 build_unflags =
 	;-DMF_STEPPER_SUPPORT					; this is just an example how to deactivate a device

--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -42,7 +42,7 @@ namespace Analog
         if (analogRegistered == maxAnalogIn)
             return;
 
-        analog[analogRegistered] = MFAnalog();
+        new (&analog[analogRegistered]) MFAnalog();
         analog[analogRegistered].attach(pin, name, sensitivity, deprecated);
         MFAnalog::attachHandler(handlerOnAnalogChange);
         analogRegistered++;

--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -29,6 +29,7 @@ namespace Analog
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         analog = static_cast<MFAnalog *>(MF_ALLOC_TYPE(MFAnalog, count));
         if (!analog) return false;
 

--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -29,13 +29,9 @@ namespace Analog
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFAnalog) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        analog = new (allocateMemory(sizeof(MFAnalog) * count)) MFAnalog;
-#else
-        analog = allocateArray<MFAnalog>(count);
-#endif
+        analog = static_cast<MFAnalog *>(MF_ALLOC_TYPE(MFAnalog, count));
+        if (!analog) return false;
+
         maxAnalogIn = count;
         return true;
     }

--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -31,7 +31,7 @@ namespace Analog
     {
         if (!FitInMemory(sizeof(MFAnalog) * count))
             return false;
-        analog      = new (allocateMemory(sizeof(MFAnalog) * count)) MFAnalog;
+        analog = allocateArray<MFAnalog>(count);
         maxAnalogIn = count;
         return true;
     }

--- a/src/MF_Analog/Analog.cpp
+++ b/src/MF_Analog/Analog.cpp
@@ -31,7 +31,11 @@ namespace Analog
     {
         if (!FitInMemory(sizeof(MFAnalog) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        analog = new (allocateMemory(sizeof(MFAnalog) * count)) MFAnalog;
+#else
         analog = allocateArray<MFAnalog>(count);
+#endif
         maxAnalogIn = count;
         return true;
     }

--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -30,6 +30,7 @@ void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity, bool d
     // enabling PullUp makes a nonlinear behaviour if pot is used
     if (deprecated)
         pinMode(_pin, INPUT_PULLUP);
+
     // Fill averaging buffers with initial reading
     for (uint8_t i = 0; i < ADC_MAX_AVERAGE; i++) {
         readBuffer();

--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -30,7 +30,6 @@ void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity, bool d
     // enabling PullUp makes a nonlinear behaviour if pot is used
     if (deprecated)
         pinMode(_pin, INPUT_PULLUP);
-
     // Fill averaging buffers with initial reading
     for (uint8_t i = 0; i < ADC_MAX_AVERAGE; i++) {
         readBuffer();

--- a/src/MF_Analog/MFAnalog.cpp
+++ b/src/MF_Analog/MFAnalog.cpp
@@ -30,7 +30,7 @@ void MFAnalog::attach(uint8_t pin, const char *name, uint8_t sensitivity, bool d
     // enabling PullUp makes a nonlinear behaviour if pot is used
     if (deprecated)
         pinMode(_pin, INPUT_PULLUP);
-        
+
     // Fill averaging buffers with initial reading
     for (uint8_t i = 0; i < ADC_MAX_AVERAGE; i++) {
         readBuffer();

--- a/src/MF_Button/Button.cpp
+++ b/src/MF_Button/Button.cpp
@@ -28,6 +28,7 @@ namespace Button
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         buttons = static_cast<MFButton *>(MF_ALLOC_TYPE(MFButton, count));
         if (!buttons) return false;
 

--- a/src/MF_Button/Button.cpp
+++ b/src/MF_Button/Button.cpp
@@ -40,7 +40,7 @@ namespace Button
     {
         if (buttonsRegistered == maxButtons)
             return;
-        buttons[buttonsRegistered] = MFButton();
+        new (&buttons[buttonsRegistered]) MFButton();
         buttons[buttonsRegistered].attach(pin, name);
         MFButton::attachHandler(handlerButtonOnChange);
         buttonsRegistered++;

--- a/src/MF_Button/Button.cpp
+++ b/src/MF_Button/Button.cpp
@@ -30,7 +30,12 @@ namespace Button
     {
         if (!FitInMemory(sizeof(MFButton) * count))
             return false;
-        buttons    = new (allocateMemory(sizeof(MFButton) * count)) MFButton;
+#ifdef ARDUINO_ARCH_AVR
+        buttons = new (allocateMemory(sizeof(MFButton) * count)) MFButton;
+#else
+        buttons = allocateArray<MFButton>(count);
+#endif
+
         maxButtons = count;
         return true;
     }

--- a/src/MF_Button/Button.cpp
+++ b/src/MF_Button/Button.cpp
@@ -28,13 +28,8 @@ namespace Button
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFButton) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        buttons = new (allocateMemory(sizeof(MFButton) * count)) MFButton;
-#else
-        buttons = allocateArray<MFButton>(count);
-#endif
+        buttons = static_cast<MFButton *>(MF_ALLOC_TYPE(MFButton, count));
+        if (!buttons) return false;
 
         maxButtons = count;
         return true;

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -43,7 +43,7 @@ namespace CustomDevice
     {
         if (customDeviceRegistered == maxCustomDevices)
             return;
-        customDevice[customDeviceRegistered] = MFCustomDevice();
+        new (&customDevice[customDeviceRegistered]) MFCustomDevice();
         customDevice[customDeviceRegistered].attach(adrPin, adrType, adrConfig, configFromFlash);
         customDeviceRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -31,6 +31,7 @@ namespace CustomDevice
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         customDevice = static_cast<MFCustomDevice *>(MF_ALLOC_TYPE(MFCustomDevice, count));
         if (!customDevice) return false;
 

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -33,7 +33,7 @@ namespace CustomDevice
     {
         if (!FitInMemory(sizeof(MFCustomDevice) * count))
             return false;
-        customDevice     = new (allocateMemory(sizeof(MFCustomDevice) * count)) MFCustomDevice();
+        customDevice     = allocateArray<MFCustomDevice>(count);
         maxCustomDevices = count;
         return true;
     }

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -33,7 +33,11 @@ namespace CustomDevice
     {
         if (!FitInMemory(sizeof(MFCustomDevice) * count))
             return false;
-        customDevice     = allocateArray<MFCustomDevice>(count);
+#ifdef ARDUINO_ARCH_AVR
+        customDevice = new (allocateMemory(sizeof(MFCustomDevice) * count)) MFCustomDevice();
+#else
+        customDevice = allocateArray<MFCustomDevice>(count);
+#endif
         maxCustomDevices = count;
         return true;
     }

--- a/src/MF_CustomDevice/CustomDevice.cpp
+++ b/src/MF_CustomDevice/CustomDevice.cpp
@@ -31,13 +31,9 @@ namespace CustomDevice
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFCustomDevice) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        customDevice = new (allocateMemory(sizeof(MFCustomDevice) * count)) MFCustomDevice();
-#else
-        customDevice = allocateArray<MFCustomDevice>(count);
-#endif
+        customDevice = static_cast<MFCustomDevice *>(MF_ALLOC_TYPE(MFCustomDevice, count));
+        if (!customDevice) return false;
+
         maxCustomDevices = count;
         return true;
     }

--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -43,7 +43,7 @@ namespace DigInMux
     {
         if (digInMuxRegistered == maxDigInMux)
             return;
-        digInMux[digInMuxRegistered] = MFDigInMux(&MUX, name);
+        new (&digInMux[digInMuxRegistered]) MFDigInMux(&MUX, name);
         digInMux[digInMuxRegistered].attach(dataPin, (nRegs == 1), name);
         MFDigInMux::attachHandler(handlerOnDigInMux);
         digInMuxRegistered++;

--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -31,13 +31,9 @@ namespace DigInMux
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFDigInMux) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        digInMux = new (allocateMemory(sizeof(MFDigInMux) * count)) MFDigInMux;
-#else
-        digInMux = allocateArray<MFDigInMux>(count);
-#endif
+        digInMux = static_cast<MFDigInMux *>(MF_ALLOC_TYPE(MFDigInMux, count));
+        if (!digInMux) return false;
+
         maxDigInMux = count;
         return true;
     }

--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -31,6 +31,7 @@ namespace DigInMux
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         digInMux = static_cast<MFDigInMux *>(MF_ALLOC_TYPE(MFDigInMux, count));
         if (!digInMux) return false;
 

--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -33,7 +33,11 @@ namespace DigInMux
     {
         if (!FitInMemory(sizeof(MFDigInMux) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        digInMux = new (allocateMemory(sizeof(MFDigInMux) * count)) MFDigInMux;
+#else
         digInMux = allocateArray<MFDigInMux>(count);
+#endif
         maxDigInMux = count;
         return true;
     }

--- a/src/MF_DigInMux/DigInMux.cpp
+++ b/src/MF_DigInMux/DigInMux.cpp
@@ -33,7 +33,7 @@ namespace DigInMux
     {
         if (!FitInMemory(sizeof(MFDigInMux) * count))
             return false;
-        digInMux    = new (allocateMemory(sizeof(MFDigInMux) * count)) MFDigInMux;
+        digInMux = allocateArray<MFDigInMux>(count);
         maxDigInMux = count;
         return true;
     }

--- a/src/MF_Encoder/Encoder.cpp
+++ b/src/MF_Encoder/Encoder.cpp
@@ -30,7 +30,11 @@ namespace Encoder
     {
         if (!FitInMemory(sizeof(MFEncoder) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        encoders = new (allocateMemory(sizeof(MFEncoder) * count)) MFEncoder;
+#else
         encoders = allocateArray<MFEncoder>(count);
+#endif
         maxEncoders = count;
         return true;
     }

--- a/src/MF_Encoder/Encoder.cpp
+++ b/src/MF_Encoder/Encoder.cpp
@@ -40,7 +40,7 @@ namespace Encoder
     {
         if (encodersRegistered == maxEncoders)
             return;
-        encoders[encodersRegistered] = MFEncoder();
+        new (&encoders[encodersRegistered]) MFEncoder();
         encoders[encodersRegistered].attach(pin1, pin2, encoder_type, name);
         MFEncoder::attachHandler(handlerOnEncoder);
         encodersRegistered++;

--- a/src/MF_Encoder/Encoder.cpp
+++ b/src/MF_Encoder/Encoder.cpp
@@ -30,7 +30,7 @@ namespace Encoder
     {
         if (!FitInMemory(sizeof(MFEncoder) * count))
             return false;
-        encoders    = new (allocateMemory(sizeof(MFEncoder) * count)) MFEncoder;
+        encoders = allocateArray<MFEncoder>(count);
         maxEncoders = count;
         return true;
     }

--- a/src/MF_Encoder/Encoder.cpp
+++ b/src/MF_Encoder/Encoder.cpp
@@ -28,6 +28,7 @@ namespace Encoder
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         encoders = static_cast<MFEncoder *>(MF_ALLOC_TYPE(MFEncoder, count));
         if (!encoders) return false;
 

--- a/src/MF_Encoder/Encoder.cpp
+++ b/src/MF_Encoder/Encoder.cpp
@@ -28,13 +28,9 @@ namespace Encoder
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFEncoder) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        encoders = new (allocateMemory(sizeof(MFEncoder) * count)) MFEncoder;
-#else
-        encoders = allocateArray<MFEncoder>(count);
-#endif
+        encoders = static_cast<MFEncoder *>(MF_ALLOC_TYPE(MFEncoder, count));
+        if (!encoders) return false;
+
         maxEncoders = count;
         return true;
     }

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -41,7 +41,8 @@ namespace InputShifter
     {
         if (inputShifterRegistered == maxInputShifter)
             return;
-        inputShifter[inputShifterRegistered] = MFInputShifter();
+
+        new (&inputShifter[inputShifterRegistered]) MFInputShifter();
         if (!inputShifter[inputShifterRegistered].attach(latchPin, clockPin, dataPin, modules, name)) {
             cmdMessenger.sendCmd(kStatus, F("InputShifter array does not fit into Memory"));
             return;

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -31,7 +31,7 @@ namespace InputShifter
     {
         if (!FitInMemory(sizeof(MFInputShifter) * count))
             return false;
-        inputShifter    = new (allocateMemory(sizeof(MFInputShifter) * count)) MFInputShifter;
+        inputShifter = allocateArray<MFInputShifter>(count);
         maxInputShifter = count;
         return true;
     }

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -29,6 +29,7 @@ namespace InputShifter
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         inputShifter = static_cast<MFInputShifter *>(MF_ALLOC_TYPE(MFInputShifter, count));
         if (!inputShifter) return false;
 

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -29,13 +29,8 @@ namespace InputShifter
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFInputShifter) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        inputShifter = new (allocateMemory(sizeof(MFInputShifter) * count)) MFInputShifter;
-#else
-        inputShifter = allocateArray<MFInputShifter>(count);
-#endif
+        inputShifter = static_cast<MFInputShifter *>(MF_ALLOC_TYPE(MFInputShifter, count));
+        if (!inputShifter) return false;
 
         maxInputShifter = count;
         return true;

--- a/src/MF_InputShifter/InputShifter.cpp
+++ b/src/MF_InputShifter/InputShifter.cpp
@@ -31,7 +31,12 @@ namespace InputShifter
     {
         if (!FitInMemory(sizeof(MFInputShifter) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        inputShifter = new (allocateMemory(sizeof(MFInputShifter) * count)) MFInputShifter;
+#else
         inputShifter = allocateArray<MFInputShifter>(count);
+#endif
+
         maxInputShifter = count;
         return true;
     }

--- a/src/MF_InputShifter/MFInputShifter.cpp
+++ b/src/MF_InputShifter/MFInputShifter.cpp
@@ -28,13 +28,8 @@ bool MFInputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin,
     pinMode(_clockPin, OUTPUT);
     pinMode(_dataPin, INPUT);
 
-    if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
-        return false;
-#ifdef ARDUINO_ARCH_AVR
-    _lastState = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
-#else
-    _lastState = static_cast<uint8_t *>(allocateMemory(sizeof(uint8_t) * _moduleCount, alignof(uint8_t)));
-#endif
+    _lastState = static_cast<uint8_t *>(MF_ALLOC_BYTES(_moduleCount));
+    if (!_lastState) return false;
 
     for (uint8_t i = 0; i < _moduleCount; i++) {
         _lastState[i] = 0;

--- a/src/MF_InputShifter/MFInputShifter.cpp
+++ b/src/MF_InputShifter/MFInputShifter.cpp
@@ -30,8 +30,12 @@ bool MFInputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin,
 
     if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
         return false;
+#ifdef ARDUINO_ARCH_AVR
+    _lastState = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
+#else
+    _lastState = static_cast<uint8_t *>(allocateMemory(sizeof(uint8_t) * _moduleCount, alignof(uint8_t)));
+#endif
 
-    _lastState = static_cast<uint8_t*>(allocateMemory(sizeof(uint8_t) * _moduleCount, alignof(uint8_t)));
     for (uint8_t i = 0; i < _moduleCount; i++) {
         _lastState[i] = 0;
     }

--- a/src/MF_InputShifter/MFInputShifter.cpp
+++ b/src/MF_InputShifter/MFInputShifter.cpp
@@ -31,7 +31,7 @@ bool MFInputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin,
     if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
         return false;
 
-    _lastState = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
+    _lastState = static_cast<uint8_t*>(allocateMemory(sizeof(uint8_t) * _moduleCount, alignof(uint8_t)));
     for (uint8_t i = 0; i < _moduleCount; i++) {
         _lastState[i] = 0;
     }

--- a/src/MF_LCDDisplay/LCDDisplay.cpp
+++ b/src/MF_LCDDisplay/LCDDisplay.cpp
@@ -17,6 +17,7 @@ namespace LCDDisplay
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         lcd_I2C = static_cast<MFLCDDisplay *>(MF_ALLOC_TYPE(MFLCDDisplay, count));
         if (!lcd_I2C) return false;
 

--- a/src/MF_LCDDisplay/LCDDisplay.cpp
+++ b/src/MF_LCDDisplay/LCDDisplay.cpp
@@ -19,7 +19,7 @@ namespace LCDDisplay
     {
         if (!FitInMemory(sizeof(MFLCDDisplay) * count))
             return false;
-        lcd_I2C    = new (allocateMemory(sizeof(MFLCDDisplay) * count)) MFLCDDisplay;
+        lcd_I2C = allocateArray<MFLCDDisplay>(count);
         maxLCD_I2C = count;
         return true;
     }

--- a/src/MF_LCDDisplay/LCDDisplay.cpp
+++ b/src/MF_LCDDisplay/LCDDisplay.cpp
@@ -17,13 +17,8 @@ namespace LCDDisplay
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFLCDDisplay) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        lcd_I2C = new (allocateMemory(sizeof(MFLCDDisplay) * count)) MFLCDDisplay;
-#else
-        lcd_I2C = allocateArray<MFLCDDisplay>(count);
-#endif
+        lcd_I2C = static_cast<MFLCDDisplay *>(MF_ALLOC_TYPE(MFLCDDisplay, count));
+        if (!lcd_I2C) return false;
 
         maxLCD_I2C = count;
         return true;

--- a/src/MF_LCDDisplay/LCDDisplay.cpp
+++ b/src/MF_LCDDisplay/LCDDisplay.cpp
@@ -29,7 +29,8 @@ namespace LCDDisplay
     {
         if (lcd_12cRegistered == maxLCD_I2C)
             return;
-        lcd_I2C[lcd_12cRegistered] = MFLCDDisplay();
+
+        new (&lcd_I2C[lcd_12cRegistered]) MFLCDDisplay();
         lcd_I2C[lcd_12cRegistered].attach(address, cols, lines);
         lcd_12cRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_LCDDisplay/LCDDisplay.cpp
+++ b/src/MF_LCDDisplay/LCDDisplay.cpp
@@ -19,7 +19,12 @@ namespace LCDDisplay
     {
         if (!FitInMemory(sizeof(MFLCDDisplay) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        lcd_I2C = new (allocateMemory(sizeof(MFLCDDisplay) * count)) MFLCDDisplay;
+#else
         lcd_I2C = allocateArray<MFLCDDisplay>(count);
+#endif
+
         maxLCD_I2C = count;
         return true;
     }

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -29,7 +29,8 @@ namespace Output
     {
         if (outputsRegistered == maxOutputs)
             return;
-        outputs[outputsRegistered] = MFOutput();
+
+        new (&outputs[outputsRegistered]) MFOutput();
         outputs[outputsRegistered].attach(pin);
         outputsRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -19,7 +19,11 @@ namespace Output
     {
         if (!FitInMemory(sizeof(MFOutput) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        outputs = new (allocateMemory(sizeof(MFOutput) * count)) MFOutput;
+#else
         outputs = allocateArray<MFOutput>(count);
+#endif
         maxOutputs = count;
         return true;
     }
@@ -47,8 +51,8 @@ namespace Output
     void OnSet()
     {
         // Read led state argument, interpret string as boolean
-        int output   = cmdMessenger.readInt16Arg();
-        int state = cmdMessenger.readInt16Arg();
+        int output = cmdMessenger.readInt16Arg();
+        int state  = cmdMessenger.readInt16Arg();
 
         outputs[output].set(state);
     }

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -19,7 +19,7 @@ namespace Output
     {
         if (!FitInMemory(sizeof(MFOutput) * count))
             return false;
-        outputs    = new (allocateMemory(sizeof(MFOutput) * count)) MFOutput;
+        outputs = allocateArray<MFOutput>(count);
         maxOutputs = count;
         return true;
     }

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -17,13 +17,9 @@ namespace Output
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFOutput) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        outputs = new (allocateMemory(sizeof(MFOutput) * count)) MFOutput;
-#else
-        outputs = allocateArray<MFOutput>(count);
-#endif
+        outputs = static_cast<MFOutput *>(MF_ALLOC_TYPE(MFOutput, count));
+        if (!outputs) return false;
+
         maxOutputs = count;
         return true;
     }

--- a/src/MF_Output/Output.cpp
+++ b/src/MF_Output/Output.cpp
@@ -17,6 +17,7 @@ namespace Output
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         outputs = static_cast<MFOutput *>(MF_ALLOC_TYPE(MFOutput, count));
         if (!outputs) return false;
 

--- a/src/MF_OutputShifter/MFOutputShifter.cpp
+++ b/src/MF_OutputShifter/MFOutputShifter.cpp
@@ -55,7 +55,7 @@ bool MFOutputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin
     if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
         return false;
 
-    _lastState = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
+    _lastState = static_cast<uint8_t*>(allocateMemory(sizeof(uint8_t) * _moduleCount, alignof(uint8_t)));
 
     clear();
 

--- a/src/MF_OutputShifter/MFOutputShifter.cpp
+++ b/src/MF_OutputShifter/MFOutputShifter.cpp
@@ -52,16 +52,10 @@ bool MFOutputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin
     pinMode(_clockPin, OUTPUT);
     pinMode(_dataPin, OUTPUT);
 
-    if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
-        return false;
-#ifdef ARDUINO_ARCH_AVR
-    _lastState = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
-#else
-    _lastState = static_cast<uint8_t *>(allocateMemory(sizeof(uint8_t) * _moduleCount, alignof(uint8_t)));
-#endif
+    _lastState = static_cast<uint8_t*>(MF_ALLOC_BYTES(_moduleCount));
+    if (!_lastState) return false;
 
     clear();
-
     return true;
 }
 

--- a/src/MF_OutputShifter/MFOutputShifter.cpp
+++ b/src/MF_OutputShifter/MFOutputShifter.cpp
@@ -54,8 +54,11 @@ bool MFOutputShifter::attach(uint8_t latchPin, uint8_t clockPin, uint8_t dataPin
 
     if (!FitInMemory(sizeof(uint8_t) * _moduleCount))
         return false;
-
-    _lastState = static_cast<uint8_t*>(allocateMemory(sizeof(uint8_t) * _moduleCount, alignof(uint8_t)));
+#ifdef ARDUINO_ARCH_AVR
+    _lastState = new (allocateMemory(sizeof(uint8_t) * _moduleCount)) uint8_t;
+#else
+    _lastState = static_cast<uint8_t *>(allocateMemory(sizeof(uint8_t) * _moduleCount, alignof(uint8_t)));
+#endif
 
     clear();
 

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -17,6 +17,7 @@ namespace OutputShifter
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         outputShifter = static_cast<MFOutputShifter *>(MF_ALLOC_TYPE(MFOutputShifter, count));
         if (!outputShifter) return false;
 

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -29,7 +29,8 @@ namespace OutputShifter
     {
         if (outputShifterRegistered == maxOutputShifter)
             return;
-        outputShifter[outputShifterRegistered] = MFOutputShifter();
+
+        new (&outputShifter[outputShifterRegistered]) MFOutputShifter();
         if (!outputShifter[outputShifterRegistered].attach(latchPin, clockPin, dataPin, modules)) {
             cmdMessenger.sendCmd(kStatus, F("OutputShifter array does not fit into Memory"));
             return;

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -19,7 +19,7 @@ namespace OutputShifter
     {
         if (!FitInMemory(sizeof(MFOutputShifter) * count))
             return false;
-        outputShifter    = new (allocateMemory(sizeof(MFOutputShifter) * count)) MFOutputShifter;
+        outputShifter = allocateArray<MFOutputShifter>(count);
         maxOutputShifter = count;
         return true;
     }

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -19,7 +19,12 @@ namespace OutputShifter
     {
         if (!FitInMemory(sizeof(MFOutputShifter) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        outputShifter = new (allocateMemory(sizeof(MFOutputShifter) * count)) MFOutputShifter;
+#else
         outputShifter = allocateArray<MFOutputShifter>(count);
+#endif
+
         maxOutputShifter = count;
         return true;
     }

--- a/src/MF_OutputShifter/OutputShifter.cpp
+++ b/src/MF_OutputShifter/OutputShifter.cpp
@@ -17,13 +17,8 @@ namespace OutputShifter
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFOutputShifter) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        outputShifter = new (allocateMemory(sizeof(MFOutputShifter) * count)) MFOutputShifter;
-#else
-        outputShifter = allocateArray<MFOutputShifter>(count);
-#endif
+        outputShifter = static_cast<MFOutputShifter *>(MF_ALLOC_TYPE(MFOutputShifter, count));
+        if (!outputShifter) return false;
 
         maxOutputShifter = count;
         return true;

--- a/src/MF_Segment/LedControl_dual.cpp
+++ b/src/MF_Segment/LedControl_dual.cpp
@@ -142,7 +142,7 @@ bool LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t cs
 
     if (!FitInMemory(sizeof(uint8_t) * numDevices * 2))
         return false;
-    rawdata = new (allocateMemory(sizeof(uint8_t) * numDevices * 2)) uint8_t;
+    rawdata = static_cast<uint8_t*>(allocateMemory(sizeof(uint8_t) * numDevices * 2, alignof(uint8_t)));
 
     if (isMAX()) {
         // make sure we have max 8 chips in the daisy chain
@@ -150,7 +150,7 @@ bool LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t cs
 
         if (!FitInMemory(sizeof(uint8_t) * numDevices * 8))
             return false;
-        digitBuffer = new (allocateMemory(sizeof(uint8_t) * numDevices * 8)) uint8_t;
+        digitBuffer = static_cast<uint8_t*>(allocateMemory(sizeof(uint8_t) * numDevices * 8, alignof(uint8_t)));
         maxUnits    = numDevices;
         pinMode(_dataPin, OUTPUT);
         pinMode(_clkPin, OUTPUT);

--- a/src/MF_Segment/LedControl_dual.cpp
+++ b/src/MF_Segment/LedControl_dual.cpp
@@ -140,25 +140,15 @@ bool LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t cs
     _clkPin  = clkPin;
     _csPin   = csPin;
 
-    if (!FitInMemory(sizeof(uint8_t) * numDevices * 2))
-        return false;
-#ifdef ARDUINO_ARCH_AVR
-    rawdata = new (allocateMemory(sizeof(uint8_t) * numDevices * 2)) uint8_t;
-#else
-    rawdata = static_cast<uint8_t *>(allocateMemory(sizeof(uint8_t) * numDevices * 2, alignof(uint8_t)));
-#endif
+    rawdata = static_cast<uint8_t*>(MF_ALLOC_BYTES(numDevices * 2));
+    if (!rawdata) return false;
 
     if (isMAX()) {
         // make sure we have max 8 chips in the daisy chain
         if (numDevices > 8) numDevices = 8;
 
-        if (!FitInMemory(sizeof(uint8_t) * numDevices * 8))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        digitBuffer = new (allocateMemory(sizeof(uint8_t) * numDevices * 8)) uint8_t;
-#else
-        digitBuffer = static_cast<uint8_t *>(allocateMemory(sizeof(uint8_t) * numDevices * 8, alignof(uint8_t)));
-#endif
+        digitBuffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(numDevices * 8));
+        if (!digitBuffer) return false;
 
         maxUnits = numDevices;
         pinMode(_dataPin, OUTPUT);

--- a/src/MF_Segment/LedControl_dual.cpp
+++ b/src/MF_Segment/LedControl_dual.cpp
@@ -142,7 +142,11 @@ bool LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t cs
 
     if (!FitInMemory(sizeof(uint8_t) * numDevices * 2))
         return false;
-    rawdata = static_cast<uint8_t*>(allocateMemory(sizeof(uint8_t) * numDevices * 2, alignof(uint8_t)));
+#ifdef ARDUINO_ARCH_AVR
+    rawdata = new (allocateMemory(sizeof(uint8_t) * numDevices * 2)) uint8_t;
+#else
+    rawdata = static_cast<uint8_t *>(allocateMemory(sizeof(uint8_t) * numDevices * 2, alignof(uint8_t)));
+#endif
 
     if (isMAX()) {
         // make sure we have max 8 chips in the daisy chain
@@ -150,8 +154,13 @@ bool LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t cs
 
         if (!FitInMemory(sizeof(uint8_t) * numDevices * 8))
             return false;
-        digitBuffer = static_cast<uint8_t*>(allocateMemory(sizeof(uint8_t) * numDevices * 8, alignof(uint8_t)));
-        maxUnits    = numDevices;
+#ifdef ARDUINO_ARCH_AVR
+        digitBuffer = new (allocateMemory(sizeof(uint8_t) * numDevices * 8)) uint8_t;
+#else
+        digitBuffer = static_cast<uint8_t *>(allocateMemory(sizeof(uint8_t) * numDevices * 8, alignof(uint8_t)));
+#endif
+
+        maxUnits = numDevices;
         pinMode(_dataPin, OUTPUT);
         pinMode(_clkPin, OUTPUT);
         pinMode(_csPin, OUTPUT);

--- a/src/MF_Segment/LedControl_dual.cpp
+++ b/src/MF_Segment/LedControl_dual.cpp
@@ -140,14 +140,13 @@ bool LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t cs
     _clkPin  = clkPin;
     _csPin   = csPin;
 
+    // make sure we have max 8 chips in the daisy chain
     if (numDevices > 8) numDevices = 8;
     
     rawdata = static_cast<uint8_t*>(MF_ALLOC_BYTES(numDevices * 2));
     if (!rawdata) return false;
 
     if (isMAX()) {
-        // make sure we have max 8 chips in the daisy chain
-
         digitBuffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(numDevices * 8));
         if (!digitBuffer) return false;
 

--- a/src/MF_Segment/LedControl_dual.cpp
+++ b/src/MF_Segment/LedControl_dual.cpp
@@ -140,12 +140,13 @@ bool LedControl::begin(uint8_t type, uint8_t dataPin, uint8_t clkPin, uint8_t cs
     _clkPin  = clkPin;
     _csPin   = csPin;
 
+    if (numDevices > 8) numDevices = 8;
+    
     rawdata = static_cast<uint8_t*>(MF_ALLOC_BYTES(numDevices * 2));
     if (!rawdata) return false;
 
     if (isMAX()) {
         // make sure we have max 8 chips in the daisy chain
-        if (numDevices > 8) numDevices = 8;
 
         digitBuffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(numDevices * 8));
         if (!digitBuffer) return false;

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -30,7 +30,7 @@ namespace LedSegment
         if (ledSegmentsRegistered == ledSegmentsRegistereds)
             return;
 
-        ledSegments[ledSegmentsRegistered] = MFSegments();
+        new (&ledSegments[ledSegmentsRegistered]) MFSegments();
 
         if (!ledSegments[ledSegmentsRegistered].attach(type, dataPin, csPin, clkPin, numDevices, brightness)) {
             cmdMessenger.sendCmd(kStatus, F("Led Segment array does not fit into Memory"));

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -17,6 +17,7 @@ namespace LedSegment
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         ledSegments = static_cast<MFSegments *>(MF_ALLOC_TYPE(MFSegments, count));
         if (!ledSegments) return false;
 

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -17,13 +17,8 @@ namespace LedSegment
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFSegments) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        ledSegments = new (allocateMemory(sizeof(MFSegments) * count)) MFSegments;
-#else
-        ledSegments = allocateArray<MFSegments>(count);
-#endif
+        ledSegments = static_cast<MFSegments *>(MF_ALLOC_TYPE(MFSegments, count));
+        if (!ledSegments) return false;
 
         ledSegmentsRegistereds = count;
         return true;

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -19,7 +19,12 @@ namespace LedSegment
     {
         if (!FitInMemory(sizeof(MFSegments) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        ledSegments = new (allocateMemory(sizeof(MFSegments) * count)) MFSegments;
+#else
         ledSegments = allocateArray<MFSegments>(count);
+#endif
+
         ledSegmentsRegistereds = count;
         return true;
     }

--- a/src/MF_Segment/LedSegment.cpp
+++ b/src/MF_Segment/LedSegment.cpp
@@ -19,7 +19,7 @@ namespace LedSegment
     {
         if (!FitInMemory(sizeof(MFSegments) * count))
             return false;
-        ledSegments            = new (allocateMemory(sizeof(MFSegments) * count)) MFSegments;
+        ledSegments = allocateArray<MFSegments>(count);
         ledSegmentsRegistereds = count;
         return true;
     }

--- a/src/MF_Servo/Servos.cpp
+++ b/src/MF_Servo/Servos.cpp
@@ -29,7 +29,8 @@ namespace Servos
     {
         if (servosRegistered == maxServos)
             return;
-        servos[servosRegistered] = MFServo();
+
+        new (&servos[servosRegistered]) MFServo();
         servos[servosRegistered].attach(pin, true);
         servosRegistered++;
 #ifdef DEBUG2CMDMESSENGER

--- a/src/MF_Servo/Servos.cpp
+++ b/src/MF_Servo/Servos.cpp
@@ -19,7 +19,12 @@ namespace Servos
     {
         if (!FitInMemory(sizeof(MFServo) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        servos = new (allocateMemory(sizeof(MFServo) * count)) MFServo;
+#else
         servos = allocateArray<MFServo>(count);
+#endif
+
         maxServos = count;
         return true;
     }

--- a/src/MF_Servo/Servos.cpp
+++ b/src/MF_Servo/Servos.cpp
@@ -17,13 +17,8 @@ namespace Servos
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFServo) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        servos = new (allocateMemory(sizeof(MFServo) * count)) MFServo;
-#else
-        servos = allocateArray<MFServo>(count);
-#endif
+        servos = static_cast<MFServo *>(MF_ALLOC_TYPE(MFServo, count));
+        if (!servos) return false;
 
         maxServos = count;
         return true;

--- a/src/MF_Servo/Servos.cpp
+++ b/src/MF_Servo/Servos.cpp
@@ -19,7 +19,7 @@ namespace Servos
     {
         if (!FitInMemory(sizeof(MFServo) * count))
             return false;
-        servos    = new (allocateMemory(sizeof(MFServo) * count)) MFServo;
+        servos = allocateArray<MFServo>(count);
         maxServos = count;
         return true;
     }

--- a/src/MF_Servo/Servos.cpp
+++ b/src/MF_Servo/Servos.cpp
@@ -17,6 +17,7 @@ namespace Servos
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         servos = static_cast<MFServo *>(MF_ALLOC_TYPE(MFServo, count));
         if (!servos) return false;
 

--- a/src/MF_Stepper/MFStepper.cpp
+++ b/src/MF_Stepper/MFStepper.cpp
@@ -53,6 +53,7 @@ bool MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, u
         break;
     default:
         _initialized = false;
+        return false;
         break;
     }
     _stepper->setMaxSpeed(maxSpeed);

--- a/src/MF_Stepper/MFStepper.cpp
+++ b/src/MF_Stepper/MFStepper.cpp
@@ -39,17 +39,33 @@ void MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, u
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         if (pin1 == pin3 && pin2 == pin4) // for backwards compatibility
+#ifdef ARDUINO_ARCH_AVR
+            _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+#else
             _stepper = allocateObject<AccelStepper>(AccelStepper::DRIVER, pin1, pin2);
+#endif
         else
-            _stepper = allocateObject<AccelStepper>(AccelStepper::FULL4WIRE, pin1, pin2);
+#ifdef ARDUINO_ARCH_AVR
+            _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::FULL4WIRE, pin4, pin2, pin1, pin3);
+#else
+            _stepper = allocateObject<AccelStepper>(AccelStepper::FULL4WIRE, pin4, pin2, pin1, pin3);
+#endif
         break;
     case HALF4WIRE:
+#ifdef ARDUINO_ARCH_AVR
+        _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
+#else
         _stepper = allocateObject<AccelStepper>(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
+#endif
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         break;
     case DRIVER:
+#ifdef ARDUINO_ARCH_AVR
+        _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+#else
         _stepper = allocateObject<AccelStepper>(AccelStepper::DRIVER, pin1, pin2);
+#endif
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         break;

--- a/src/MF_Stepper/MFStepper.cpp
+++ b/src/MF_Stepper/MFStepper.cpp
@@ -24,38 +24,35 @@ MFStepper::MFStepper()
     _initialized = false;
 }
 
-void MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, uint8_t btnPin5, uint8_t mode, int8_t backlash, bool deactivateOutput)
+bool MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, uint8_t btnPin5, uint8_t mode, int8_t backlash, bool deactivateOutput)
 {
-    if (!FitInMemory(sizeof(AccelStepper))) {
-        // Error Message to Connector
-        cmdMessenger.sendCmd(kStatus, F("MFStepper does not fit in Memory"));
-        return;
-    }
     uint16_t maxSpeed = 0;
     uint16_t Accel    = 0;
+
+    void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
+    if (!mem) return false;
 
     switch (mode) {
     case FULL4WIRE:
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         if (pin1 == pin3 && pin2 == pin4) // for backwards compatibility
-            _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+            _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
         else
-            _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::FULL4WIRE, pin4, pin2, pin1, pin3);
+            _stepper = new (mem) AccelStepper(AccelStepper::FULL4WIRE, pin4, pin2, pin1, pin3);
         break;
     case HALF4WIRE:
-        _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
+        _stepper = new (mem) AccelStepper(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         break;
     case DRIVER:
-        _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+        _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         break;
     default:
         _initialized = false;
-        return;
         break;
     }
     _stepper->setMaxSpeed(maxSpeed);
@@ -73,6 +70,8 @@ void MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, u
     _resetting        = false;
     _isStopped        = true;
     _inMove           = MOVE_CW;
+
+    return true;
 }
 
 void MFStepper::detach()

--- a/src/MF_Stepper/MFStepper.cpp
+++ b/src/MF_Stepper/MFStepper.cpp
@@ -39,33 +39,17 @@ void MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, u
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         if (pin1 == pin3 && pin2 == pin4) // for backwards compatibility
-#ifdef ARDUINO_ARCH_AVR
-            _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
-#else
-            _stepper = allocateObject<AccelStepper>(AccelStepper::DRIVER, pin1, pin2);
-#endif
+            _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
         else
-#ifdef ARDUINO_ARCH_AVR
-            _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::FULL4WIRE, pin4, pin2, pin1, pin3);
-#else
-            _stepper = allocateObject<AccelStepper>(AccelStepper::FULL4WIRE, pin4, pin2, pin1, pin3);
-#endif
+            _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::FULL4WIRE, pin4, pin2, pin1, pin3);
         break;
     case HALF4WIRE:
-#ifdef ARDUINO_ARCH_AVR
-        _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
-#else
-        _stepper = allocateObject<AccelStepper>(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
-#endif
+        _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         break;
     case DRIVER:
-#ifdef ARDUINO_ARCH_AVR
-        _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
-#else
-        _stepper = allocateObject<AccelStepper>(AccelStepper::DRIVER, pin1, pin2);
-#endif
+        _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         break;
@@ -74,7 +58,9 @@ void MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, u
         return;
         break;
     }
-
+    // Checking if the class could be initialized is missing!
+    // attach() must be changed from void to bool and add() in
+    // stepper.cpp must also be changed
     _stepper->setMaxSpeed(maxSpeed);
     _stepper->setAcceleration(Accel);
     _zeroPin      = btnPin5;

--- a/src/MF_Stepper/MFStepper.cpp
+++ b/src/MF_Stepper/MFStepper.cpp
@@ -39,17 +39,17 @@ void MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, u
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         if (pin1 == pin3 && pin2 == pin4) // for backwards compatibility
-            _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+            _stepper = allocateObject<AccelStepper>(AccelStepper::DRIVER, pin1, pin2);
         else
-            _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::FULL4WIRE, pin4, pin2, pin1, pin3);
+            _stepper = allocateObject<AccelStepper>(AccelStepper::FULL4WIRE, pin1, pin2);
         break;
     case HALF4WIRE:
-        _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
+        _stepper = allocateObject<AccelStepper>(AccelStepper::HALF4WIRE, pin4, pin2, pin1, pin3);
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         break;
     case DRIVER:
-        _stepper = new (allocateMemory(sizeof(AccelStepper))) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+        _stepper = allocateObject<AccelStepper>(AccelStepper::DRIVER, pin1, pin2);
         maxSpeed = STEPPER_SPEED;
         Accel    = STEPPER_ACCEL;
         break;

--- a/src/MF_Stepper/MFStepper.cpp
+++ b/src/MF_Stepper/MFStepper.cpp
@@ -58,9 +58,6 @@ void MFStepper::attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, u
         return;
         break;
     }
-    // Checking if the class could be initialized is missing!
-    // attach() must be changed from void to bool and add() in
-    // stepper.cpp must also be changed
     _stepper->setMaxSpeed(maxSpeed);
     _stepper->setAcceleration(Accel);
     _zeroPin      = btnPin5;

--- a/src/MF_Stepper/MFStepper.h
+++ b/src/MF_Stepper/MFStepper.h
@@ -16,7 +16,7 @@ class MFStepper
 
 public:
     MFStepper();
-    void attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, uint8_t btnPin1, uint8_t mode, int8_t backlash, bool deactivateOutput);
+    bool attach(uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, uint8_t btnPin1, uint8_t mode, int8_t backlash, bool deactivateOutput);
     void detach();
     void update();
     void reset();

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -28,13 +28,8 @@ namespace Stepper
 
     bool setupArray(uint16_t count)
     {
-        if (!FitInMemory(sizeof(MFStepper) * count))
-            return false;
-#ifdef ARDUINO_ARCH_AVR
-        steppers = new (allocateMemory(sizeof(MFStepper) * count)) MFStepper;
-#else
-        steppers = allocateArray<MFStepper>(count);
-#endif
+        steppers = static_cast<MFStepper *>(MF_ALLOC_TYPE(MFStepper, count));
+        if (!steppers) return false;
 
         maxSteppers = count;
         return true;

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -28,6 +28,7 @@ namespace Stepper
 
     bool setupArray(uint16_t count)
     {
+        if (!count) return true;
         steppers = static_cast<MFStepper *>(MF_ALLOC_TYPE(MFStepper, count));
         if (!steppers) return false;
 

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -30,7 +30,12 @@ namespace Stepper
     {
         if (!FitInMemory(sizeof(MFStepper) * count))
             return false;
+#ifdef ARDUINO_ARCH_AVR
+        steppers = new (allocateMemory(sizeof(MFStepper) * count)) MFStepper;
+#else
         steppers = allocateArray<MFStepper>(count);
+#endif
+
         maxSteppers = count;
         return true;
     }

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -40,7 +40,8 @@ namespace Stepper
     {
         if (steppersRegistered == maxSteppers)
             return;
-        steppers[steppersRegistered] = MFStepper();
+
+        new (&steppers[steppersRegistered]) MFStepper();
         if (!steppers[steppersRegistered].attach(pin1, pin2, pin3, pin4, btnPin1, mode, backlash, deactivateOutput)) {
             cmdMessenger.sendCmd(kStatus, F("Stepper array does not fit into Memory"));
             return;

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -41,7 +41,10 @@ namespace Stepper
         if (steppersRegistered == maxSteppers)
             return;
         steppers[steppersRegistered] = MFStepper();
-        steppers[steppersRegistered].attach(pin1, pin2, pin3, pin4, btnPin1, mode, backlash, deactivateOutput);
+        if (!steppers[steppersRegistered].attach(pin1, pin2, pin3, pin4, btnPin1, mode, backlash, deactivateOutput)) {
+            cmdMessenger.sendCmd(kStatus, F("Stepper array does not fit into Memory"));
+            return;
+        }
 
         if (btnPin1 > 0) {
             // this triggers the auto reset if we need to reset

--- a/src/MF_Stepper/Stepper.cpp
+++ b/src/MF_Stepper/Stepper.cpp
@@ -30,7 +30,7 @@ namespace Stepper
     {
         if (!FitInMemory(sizeof(MFStepper) * count))
             return false;
-        steppers    = new (allocateMemory(sizeof(MFStepper) * count)) MFStepper;
+        steppers = allocateArray<MFStepper>(count);
         maxSteppers = count;
         return true;
     }

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -10,9 +10,9 @@
 #ifdef ARDUINO_ARCH_AVR
 
 static uint8_t  deviceBuffer[MF_MAX_DEVICEMEM] = {0};
-static uint16_t nextPointer = 0;
+static uint16_t nextPointer                    = 0;
 
-void* allocateMemory(uint16_t size)
+void *allocateMemory(uint16_t size)
 {
     uint16_t actualPointer = nextPointer;
     uint16_t newPointer    = actualPointer + size;
@@ -21,6 +21,7 @@ void* allocateMemory(uint16_t size)
         cmdMessenger.sendCmd(kStatus, F("DeviceBuffer Overflow!"));
         return nullptr;
     }
+    nextPointer = newPointer;
 #ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmdStart(kDebug);
     cmdMessenger.sendCmdArg(F("Bytes added"));
@@ -31,7 +32,6 @@ void* allocateMemory(uint16_t size)
     cmdMessenger.sendCmdArg(nextPointer);
     cmdMessenger.sendCmdEnd();
 #endif
-    nextPointer = newPointer;
     return &deviceBuffer[actualPointer];
 }
 
@@ -52,17 +52,15 @@ bool FitInMemory(uint16_t size)
 
 #else
 
-
-//alignas(max_align_t) static uint8_t deviceBuffer[MF_MAX_DEVICEMEM] = {0};
 alignas(max_align_t) static uint8_t deviceBuffer[MF_MAX_DEVICEMEM] = {0};
-static size_t nextPointer = 0;
+static size_t nextPointer                                          = 0;
 
 static size_t alignUp(size_t value, size_t alignment)
 {
     return (value + alignment - 1u) & ~(alignment - 1u);
 }
 
-void* allocateMemory(size_t size, size_t alignment)
+void *allocateMemory(size_t size, size_t alignment)
 {
     if (size == 0) {
         return nullptr;
@@ -90,7 +88,6 @@ void* allocateMemory(size_t size, size_t alignment)
     cmdMessenger.sendCmdArg(nextPointer);
     cmdMessenger.sendCmdEnd();
 #endif
-
     return &deviceBuffer[actualPointer];
 }
 
@@ -113,7 +110,6 @@ bool FitInMemory(size_t size, size_t alignment)
     if (alignment == 0) {
         alignment = 1;
     }
-
     size_t actualPointer = alignUp(nextPointer, alignment);
     size_t newPointer    = actualPointer + size;
 

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -28,7 +28,7 @@ void *allocateMemory(size_t size, size_t alignment)
         return nullptr;
     }
     nextPointer = newPointer;
-#ifndef DEBUG2CMDMESSENGER
+#ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmdStart(kDebug);
     cmdMessenger.sendCmdArg(F("Bytes added"));
     cmdMessenger.sendCmdArg(size);

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -7,26 +7,32 @@
 #include "allocateMem.h"
 #include "commandmessenger.h"
 
-#ifdef ARDUINO_ARCH_AVR
-uint8_t deviceBuffer[MF_MAX_DEVICEMEM] = {0};
-#else
-std::size_t deviceBuffer[MF_MAX_DEVICEMEM] = {0};
-#endif
+alignas(max_align_t) static uint8_t deviceBuffer[MF_MAX_DEVICEMEM] = {0};
+static size_t nextPointer = 0;
 
-uint16_t nextPointer = 0;
-
-#ifdef ARDUINO_ARCH_AVR
-uint8_t *allocateMemory(uint16_t size)
-#else
-std::size_t *allocateMemory(uint16_t size)
-#endif
+static size_t alignUp(size_t value, size_t alignment)
 {
-    uint16_t actualPointer = nextPointer;
-    nextPointer            = actualPointer + size;
-    if (nextPointer >= MF_MAX_DEVICEMEM) {
+    return (value + alignment - 1u) & ~(alignment - 1u);
+}
+
+void* allocateMemory(size_t size, size_t alignment)
+{
+    if (size == 0) {
+        return nullptr;
+    }
+
+    if (alignment == 0) {
+        alignment = 1;
+    }
+
+    size_t actualPointer = alignUp(nextPointer, alignment);
+    size_t newPointer    = actualPointer + size;
+
+    if (newPointer > MF_MAX_DEVICEMEM) {
         cmdMessenger.sendCmd(kStatus, F("DeviceBuffer Overflow!"));
         return nullptr;
     }
+
 #ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmdStart(kDebug);
     cmdMessenger.sendCmdArg(F("Bytes added"));
@@ -37,6 +43,8 @@ std::size_t *allocateMemory(uint16_t size)
     cmdMessenger.sendCmdArg(nextPointer);
     cmdMessenger.sendCmdEnd();
 #endif
+
+    nextPointer = newPointer;
     return &deviceBuffer[actualPointer];
 }
 
@@ -45,16 +53,25 @@ void ClearMemory()
     nextPointer = 0;
 }
 
-uint16_t GetAvailableMemory()
+size_t GetAvailableMemory()
 {
     return MF_MAX_DEVICEMEM - nextPointer;
 }
 
-bool FitInMemory(uint16_t size)
+bool FitInMemory(size_t size, size_t alignment)
 {
-    if (nextPointer + size > MF_MAX_DEVICEMEM)
-        return false;
-    return true;
+    if (size == 0) {
+        return true;
+    }
+
+    if (alignment == 0) {
+        alignment = 1;
+    }
+
+    size_t actualPointer = alignUp(nextPointer, alignment);
+    size_t newPointer    = actualPointer + size;
+
+    return (newPointer <= MF_MAX_DEVICEMEM);
 }
 
 // allocatemem.cpp

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -50,16 +50,4 @@ size_t GetAvailableMemory()
 {
     return MF_MAX_DEVICEMEM - nextPointer;
 }
-
-bool FitInMemory(size_t size, size_t alignment)
-{
-    if (size == 0) return true;
-    if (alignment == 0) alignment = 1;
-
-    size_t actualPointer = alignUp(nextPointer, alignment);
-    size_t newPointer    = actualPointer + size;
-
-    return (newPointer <= MF_MAX_DEVICEMEM);
-}
-
 // allocatemem.cpp

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -12,7 +12,12 @@ static size_t nextPointer                                          = 0;
 
 static size_t alignUp(size_t value, size_t alignment)
 {
-    return (value + alignment - 1u) & ~(alignment - 1u);
+    if (alignment == 0) return value;
+
+    size_t remainder = value % alignment;
+    if (remainder == 0) return value;
+
+    return value + (alignment - remainder);
 }
 
 void *allocateMemory(size_t size, size_t alignment)

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -7,51 +7,6 @@
 #include "allocateMem.h"
 #include "commandmessenger.h"
 
-#ifdef ARDUINO_ARCH_AVR
-
-static uint8_t  deviceBuffer[MF_MAX_DEVICEMEM] = {0};
-static uint16_t nextPointer                    = 0;
-
-void *allocateMemory(uint16_t size)
-{
-    uint16_t actualPointer = nextPointer;
-    uint16_t newPointer    = actualPointer + size;
-
-    if (newPointer > MF_MAX_DEVICEMEM) {
-        cmdMessenger.sendCmd(kStatus, F("DeviceBuffer Overflow!"));
-        return nullptr;
-    }
-    nextPointer = newPointer;
-#ifdef DEBUG2CMDMESSENGER
-    cmdMessenger.sendCmdStart(kDebug);
-    cmdMessenger.sendCmdArg(F("Bytes added"));
-    cmdMessenger.sendCmdArg(size);
-    cmdMessenger.sendCmdEnd();
-    cmdMessenger.sendCmdStart(kDebug);
-    cmdMessenger.sendCmdArg(F("BufferUsage"));
-    cmdMessenger.sendCmdArg(nextPointer);
-    cmdMessenger.sendCmdEnd();
-#endif
-    return &deviceBuffer[actualPointer];
-}
-
-void ClearMemory()
-{
-    nextPointer = 0;
-}
-
-uint16_t GetAvailableMemory()
-{
-    return MF_MAX_DEVICEMEM - nextPointer;
-}
-
-bool FitInMemory(uint16_t size)
-{
-    return (nextPointer + size <= MF_MAX_DEVICEMEM);
-}
-
-#else
-
 alignas(max_align_t) static uint8_t deviceBuffer[MF_MAX_DEVICEMEM] = {0};
 static size_t nextPointer                                          = 0;
 
@@ -62,13 +17,8 @@ static size_t alignUp(size_t value, size_t alignment)
 
 void *allocateMemory(size_t size, size_t alignment)
 {
-    if (size == 0) {
-        return nullptr;
-    }
-
-    if (alignment == 0) {
-        alignment = 1;
-    }
+    if (size == 0) return nullptr;
+    if (alignment == 0) alignment = 1;
 
     size_t actualPointer = alignUp(nextPointer, alignment);
     size_t newPointer    = actualPointer + size;
@@ -103,18 +53,13 @@ size_t GetAvailableMemory()
 
 bool FitInMemory(size_t size, size_t alignment)
 {
-    if (size == 0) {
-        return true;
-    }
+    if (size == 0) return true;
+    if (alignment == 0) alignment = 1;
 
-    if (alignment == 0) {
-        alignment = 1;
-    }
     size_t actualPointer = alignUp(nextPointer, alignment);
     size_t newPointer    = actualPointer + size;
 
     return (newPointer <= MF_MAX_DEVICEMEM);
 }
 
-#endif
 // allocatemem.cpp

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -21,13 +21,14 @@ void *allocateMemory(size_t size, size_t alignment)
     if (alignment == 0) alignment = 1;
 
     size_t actualPointer = alignUp(nextPointer, alignment);
-    size_t newPointer    = actualPointer + size;
 
-    if (newPointer > MF_MAX_DEVICEMEM) {
+    if (actualPointer > MF_MAX_DEVICEMEM || size > MF_MAX_DEVICEMEM - actualPointer) {
         cmdMessenger.sendCmd(kStatus, F("DeviceBuffer Overflow!"));
         return nullptr;
     }
-    nextPointer = newPointer;
+
+    size_t newPointer = actualPointer + size;
+    nextPointer       = newPointer;
 #ifdef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmdStart(kDebug);
     cmdMessenger.sendCmdArg(F("Bytes added"));

--- a/src/allocateMem.cpp
+++ b/src/allocateMem.cpp
@@ -7,6 +7,53 @@
 #include "allocateMem.h"
 #include "commandmessenger.h"
 
+#ifdef ARDUINO_ARCH_AVR
+
+static uint8_t  deviceBuffer[MF_MAX_DEVICEMEM] = {0};
+static uint16_t nextPointer = 0;
+
+void* allocateMemory(uint16_t size)
+{
+    uint16_t actualPointer = nextPointer;
+    uint16_t newPointer    = actualPointer + size;
+
+    if (newPointer > MF_MAX_DEVICEMEM) {
+        cmdMessenger.sendCmd(kStatus, F("DeviceBuffer Overflow!"));
+        return nullptr;
+    }
+#ifdef DEBUG2CMDMESSENGER
+    cmdMessenger.sendCmdStart(kDebug);
+    cmdMessenger.sendCmdArg(F("Bytes added"));
+    cmdMessenger.sendCmdArg(size);
+    cmdMessenger.sendCmdEnd();
+    cmdMessenger.sendCmdStart(kDebug);
+    cmdMessenger.sendCmdArg(F("BufferUsage"));
+    cmdMessenger.sendCmdArg(nextPointer);
+    cmdMessenger.sendCmdEnd();
+#endif
+    nextPointer = newPointer;
+    return &deviceBuffer[actualPointer];
+}
+
+void ClearMemory()
+{
+    nextPointer = 0;
+}
+
+uint16_t GetAvailableMemory()
+{
+    return MF_MAX_DEVICEMEM - nextPointer;
+}
+
+bool FitInMemory(uint16_t size)
+{
+    return (nextPointer + size <= MF_MAX_DEVICEMEM);
+}
+
+#else
+
+
+//alignas(max_align_t) static uint8_t deviceBuffer[MF_MAX_DEVICEMEM] = {0};
 alignas(max_align_t) static uint8_t deviceBuffer[MF_MAX_DEVICEMEM] = {0};
 static size_t nextPointer = 0;
 
@@ -32,8 +79,8 @@ void* allocateMemory(size_t size, size_t alignment)
         cmdMessenger.sendCmd(kStatus, F("DeviceBuffer Overflow!"));
         return nullptr;
     }
-
-#ifdef DEBUG2CMDMESSENGER
+    nextPointer = newPointer;
+#ifndef DEBUG2CMDMESSENGER
     cmdMessenger.sendCmdStart(kDebug);
     cmdMessenger.sendCmdArg(F("Bytes added"));
     cmdMessenger.sendCmdArg(size);
@@ -44,7 +91,6 @@ void* allocateMemory(size_t size, size_t alignment)
     cmdMessenger.sendCmdEnd();
 #endif
 
-    nextPointer = newPointer;
     return &deviceBuffer[actualPointer];
 }
 
@@ -74,4 +120,5 @@ bool FitInMemory(size_t size, size_t alignment)
     return (newPointer <= MF_MAX_DEVICEMEM);
 }
 
+#endif
 // allocatemem.cpp

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -9,10 +9,21 @@
 #include <Arduino.h>
 #include <new>
 
-void* allocateMemory(size_t size, size_t alignment = alignof(max_align_t));
-void  ClearMemory();
+#ifdef ARDUINO_ARCH_AVR
+
+void*    allocateMemory(uint16_t size);
+void     ClearMemory();
+uint16_t GetAvailableMemory();
+bool     FitInMemory(uint16_t size);
+
+#else
+
+void*  allocateMemory(size_t size, size_t alignment = alignof(max_align_t));
+void   ClearMemory();
 size_t GetAvailableMemory();
-bool  FitInMemory(size_t size, size_t alignment = alignof(max_align_t));
+bool   FitInMemory(size_t size, size_t alignment = alignof(max_align_t));
+
+#endif
 
 template <typename T, typename... Args>
 T* allocateObject(Args&&... args)

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -9,7 +9,7 @@
 //      if (!mem) return false;
 //      _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
 //
-// Object array with paramters in class, calls the constructor
+// Object array with parameters in class, calls the constructor
 //      MFTestClass* _testClass = static_cast<MFTestClass*>(MF_ALLOC_TYPE(MFTestClass, count));
 //      if (!_testClass) return false;
 //      for (uint8_t i = 0; i < count; i++) {

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -9,14 +9,53 @@
 #include <Arduino.h>
 #include <new>
 
-#ifdef ARDUINO_ARCH_AVR
-uint8_t *allocateMemory(uint16_t size);
-#else
-std::size_t *allocateMemory(uint16_t size);
-#endif
+void* allocateMemory(size_t size, size_t alignment = alignof(max_align_t));
+void  ClearMemory();
+size_t GetAvailableMemory();
+bool  FitInMemory(size_t size, size_t alignment = alignof(max_align_t));
 
-void     ClearMemory();
-uint16_t GetAvailableMemory();
-bool     FitInMemory(uint16_t size);
+template <typename T, typename... Args>
+T* allocateObject(Args&&... args)
+{
+    void* mem = allocateMemory(sizeof(T), alignof(T));
+    if (!mem) return nullptr;
+    return new (mem) T(static_cast<Args&&>(args)...);
+}
+
+// Array with Default-Konstruktor
+template <typename T>
+T* allocateArray(size_t count)
+{
+    if (count == 0) return nullptr;
+
+    void* mem = allocateMemory(sizeof(T) * count, alignof(T));
+    if (!mem) return nullptr;
+
+    T* arr = static_cast<T*>(mem);
+
+    for (size_t i = 0; i < count; ++i) {
+        new (&arr[i]) T();
+    }
+
+    return arr;
+}
+
+// Array with all Elements of same Arguments
+template <typename T, typename... Args>
+T* allocateArray(size_t count, Args... args)
+{
+    if (count == 0) return nullptr;
+
+    void* mem = allocateMemory(sizeof(T) * count, alignof(T));
+    if (!mem) return nullptr;
+
+    T* arr = static_cast<T*>(mem);
+
+    for (size_t i = 0; i < count; ++i) {
+        new (&arr[i]) T(args...);
+    }
+
+    return arr;
+}
 
 // allocatemem.h

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -4,26 +4,34 @@
 // (C) MobiFlight Project 2022
 //
 // 
-// Single Object, avoids calling 'placement new' with nullptr
-//     void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
-//     if (mem) {
-//         _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
-//     } else {
-//         // handle error
-//         return;
-//     }
+// Single Object with constructor, avoids calling 'placement new' with nullptr
+//      void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
+//      if (!mem) return false;
+//      _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
 // 
-// Object array
-//     _encoders = static_cast<MFEncoder*>(MF_ALLOC_TYPE(MFEncoder, count));
-// 
+// Object array with paramters in class, calls the constructor
+//      MFTestClass* _testClass = static_cast<MFTestClass*>(MF_ALLOC_TYPE(MFTestClass, count));
+//      if (!_testClass) return false;
+//      for (uint8_t i = 0; i < count; i++) {
+//          new (&_testClass[i]) MFTestClass(pin1, pin2);
+//      }
+//  and destructor if available
+//      for (uint8_t i = 0; i < count; i++) {
+//          _testClass[i].~MFTestClass();
+//      }
+//
+// Object array without constructor, paramters via _encoders.begin(x,y)
+//      _encoders = static_cast<MFEncoder*>(MF_ALLOC_TYPE(MFEncoder, count));
+//      if (!_encoders) return false;
+//
 // uint8_t-Array
-//     _buffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(count));
+//      _buffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(count));
 // 
 // uint16_t-Array
-//     _values = static_cast<uint16_t*>(MF_ALLOC_TYPE(uint16_t, count));
+//      _values = static_cast<uint16_t*>(MF_ALLOC_TYPE(uint16_t, count));
 // 
 // uint32_t-Array
-//     _values = static_cast<uint32_t*>(MF_ALLOC_TYPE(uint32_t, count));
+//      _values = static_cast<uint32_t*>(MF_ALLOC_TYPE(uint32_t, count));
 // 
 
 #pragma once

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -3,6 +3,28 @@
 //
 // (C) MobiFlight Project 2022
 //
+// 
+// Single Object, avoids calling 'placement new' with nullptr
+//     void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
+//     if (mem) {
+//         _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+//     } else {
+//         // handle error
+//         return;
+//     }
+// 
+// Object array
+//     _encoders = static_cast<MFEncoder*>(MF_ALLOC_TYPE(MFEncoder, count));
+// 
+// uint8_t-Array
+//     _buffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(count));
+// 
+// uint16_t-Array
+//     _values = static_cast<uint16_t*>(MF_ALLOC_TYPE(uint16_t, count));
+// 
+// uint32_t-Array
+//     _values = static_cast<uint32_t*>(MF_ALLOC_TYPE(uint32_t, count));
+// 
 
 #pragma once
 
@@ -17,27 +39,3 @@ void   ClearMemory();
 size_t GetAvailableMemory();
 
 // allocatemem.h
-
-/*
-Single Object, avoids calling 'placement new' with nullptr
-    void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
-    if (mem) {
-        _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
-    } else {
-        // handle error
-        return;
-    }
-
-Object array
-    _encoders = static_cast<MFEncoder*>(MF_ALLOC_TYPE(MFEncoder, count));
-
-uint8_t-Array
-    _buffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(count));
-
-uint16_t-Array
-    _values = static_cast<uint16_t*>(MF_ALLOC_TYPE(uint16_t, count));
-
-uint32_t-Array
-    _values = static_cast<uint32_t*>(MF_ALLOC_TYPE(uint32_t, count));
-
-*/

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -10,39 +10,35 @@
 #include <new>
 
 #ifdef ARDUINO_ARCH_AVR
-
-void*    allocateMemory(uint16_t size);
+void    *allocateMemory(uint16_t size);
 void     ClearMemory();
 uint16_t GetAvailableMemory();
 bool     FitInMemory(uint16_t size);
-
 #else
-
-void*  allocateMemory(size_t size, size_t alignment = alignof(max_align_t));
+void  *allocateMemory(size_t size, size_t alignment = alignof(max_align_t));
 void   ClearMemory();
 size_t GetAvailableMemory();
 bool   FitInMemory(size_t size, size_t alignment = alignof(max_align_t));
 
-#endif
-
 template <typename T, typename... Args>
-T* allocateObject(Args&&... args)
+// Class with Default-Konstruktor
+T *allocateObject(Args &&...args)
 {
-    void* mem = allocateMemory(sizeof(T), alignof(T));
+    void *mem = allocateMemory(sizeof(T), alignof(T));
     if (!mem) return nullptr;
-    return new (mem) T(static_cast<Args&&>(args)...);
+    return new (mem) T(static_cast<Args &&>(args)...);
 }
 
-// Array with Default-Konstruktor
+// Array of Classes with Default-Konstruktor
 template <typename T>
-T* allocateArray(size_t count)
+T *allocateArray(size_t count)
 {
     if (count == 0) return nullptr;
 
-    void* mem = allocateMemory(sizeof(T) * count, alignof(T));
+    void *mem = allocateMemory(sizeof(T) * count, alignof(T));
     if (!mem) return nullptr;
 
-    T* arr = static_cast<T*>(mem);
+    T *arr = static_cast<T *>(mem);
 
     for (size_t i = 0; i < count; ++i) {
         new (&arr[i]) T();
@@ -51,16 +47,16 @@ T* allocateArray(size_t count)
     return arr;
 }
 
-// Array with all Elements of same Arguments
+// Array of Classes with all Elements of same Arguments
 template <typename T, typename... Args>
-T* allocateArray(size_t count, Args... args)
+T *allocateArray(size_t count, Args... args)
 {
     if (count == 0) return nullptr;
 
-    void* mem = allocateMemory(sizeof(T) * count, alignof(T));
+    void *mem = allocateMemory(sizeof(T) * count, alignof(T));
     if (!mem) return nullptr;
 
-    T* arr = static_cast<T*>(mem);
+    T *arr = static_cast<T *>(mem);
 
     for (size_t i = 0; i < count; ++i) {
         new (&arr[i]) T(args...);
@@ -68,5 +64,5 @@ T* allocateArray(size_t count, Args... args)
 
     return arr;
 }
-
+#endif
 // allocatemem.h

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -9,60 +9,43 @@
 #include <Arduino.h>
 #include <new>
 
-#ifdef ARDUINO_ARCH_AVR
-void    *allocateMemory(uint16_t size);
-void     ClearMemory();
-uint16_t GetAvailableMemory();
-bool     FitInMemory(uint16_t size);
-#else
+#define MF_ALLOC_BYTES(count)   allocateMemory((size_t)(count), 1)
+#define MF_ALLOC_TYPE(T, count) allocateMemory((size_t)(sizeof(T) * (count)), alignof(T))
+
 void  *allocateMemory(size_t size, size_t alignment = alignof(max_align_t));
 void   ClearMemory();
 size_t GetAvailableMemory();
 bool   FitInMemory(size_t size, size_t alignment = alignof(max_align_t));
 
-template <typename T, typename... Args>
-// Class with Default-Konstruktor
-T *allocateObject(Args &&...args)
-{
-    void *mem = allocateMemory(sizeof(T), alignof(T));
-    if (!mem) return nullptr;
-    return new (mem) T(static_cast<Args &&>(args)...);
-}
-
-// Array of Classes with Default-Konstruktor
-template <typename T>
-T *allocateArray(size_t count)
-{
-    if (count == 0) return nullptr;
-
-    void *mem = allocateMemory(sizeof(T) * count, alignof(T));
-    if (!mem) return nullptr;
-
-    T *arr = static_cast<T *>(mem);
-
-    for (size_t i = 0; i < count; ++i) {
-        new (&arr[i]) T();
-    }
-
-    return arr;
-}
-
-// Array of Classes with all Elements of same Arguments
-template <typename T, typename... Args>
-T *allocateArray(size_t count, Args... args)
-{
-    if (count == 0) return nullptr;
-
-    void *mem = allocateMemory(sizeof(T) * count, alignof(T));
-    if (!mem) return nullptr;
-
-    T *arr = static_cast<T *>(mem);
-
-    for (size_t i = 0; i < count; ++i) {
-        new (&arr[i]) T(args...);
-    }
-
-    return arr;
-}
-#endif
 // allocatemem.h
+
+/*
+Single Object
+    either:
+        void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
+        if (mem) {
+            _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+        } else {
+            // handle error
+            return;
+        }
+    or:
+        if (!FitInMemory(sizeof(AccelStepper))) {
+            // handle error
+            return;
+        }
+        _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+
+Object array
+    _encoders = static_cast<MFEncoder*>(MF_ALLOC_TYPE(MFEncoder, count));
+
+uint8_t-Array
+    _buffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(count));
+
+uint16_t-Array
+    _values = static_cast<uint16_t*>(MF_ALLOC_TYPE(uint16_t, count));
+
+uint32_t-Array
+    _values = static_cast<uint32_t*>(MF_ALLOC_TYPE(uint16_t, count));
+
+*/

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -3,12 +3,12 @@
 //
 // (C) MobiFlight Project 2022
 //
-// 
+//
 // Single Object with constructor, avoids calling 'placement new' with nullptr
 //      void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
 //      if (!mem) return false;
 //      _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
-// 
+//
 // Object array with paramters in class, calls the constructor
 //      MFTestClass* _testClass = static_cast<MFTestClass*>(MF_ALLOC_TYPE(MFTestClass, count));
 //      if (!_testClass) return false;
@@ -26,13 +26,13 @@
 //
 // uint8_t-Array
 //      _buffer = static_cast<uint8_t*>(MF_ALLOC_BYTES(count));
-// 
+//
 // uint16_t-Array
 //      _values = static_cast<uint16_t*>(MF_ALLOC_TYPE(uint16_t, count));
-// 
+//
 // uint32_t-Array
 //      _values = static_cast<uint32_t*>(MF_ALLOC_TYPE(uint32_t, count));
-// 
+//
 
 #pragma once
 

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -15,26 +15,18 @@
 void  *allocateMemory(size_t size, size_t alignment = alignof(max_align_t));
 void   ClearMemory();
 size_t GetAvailableMemory();
-bool   FitInMemory(size_t size, size_t alignment = alignof(max_align_t));
 
 // allocatemem.h
 
 /*
-Single Object
-    either:
-        void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
-        if (mem) {
-            _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
-        } else {
-            // handle error
-            return;
-        }
-    or:
-        if (!FitInMemory(sizeof(AccelStepper))) {
-            // handle error
-            return;
-        }
-        _stepper = new (MF_ALLOC_TYPE(AccelStepper, 1)) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+Single Object, avoids calling 'placement new' with nullptr
+    void* mem = MF_ALLOC_TYPE(AccelStepper, 1);
+    if (mem) {
+        _stepper = new (mem) AccelStepper(AccelStepper::DRIVER, pin1, pin2);
+    } else {
+        // handle error
+        return;
+    }
 
 Object array
     _encoders = static_cast<MFEncoder*>(MF_ALLOC_TYPE(MFEncoder, count));

--- a/src/allocateMem.h
+++ b/src/allocateMem.h
@@ -46,6 +46,6 @@ uint16_t-Array
     _values = static_cast<uint16_t*>(MF_ALLOC_TYPE(uint16_t, count));
 
 uint32_t-Array
-    _values = static_cast<uint32_t*>(MF_ALLOC_TYPE(uint16_t, count));
+    _values = static_cast<uint32_t*>(MF_ALLOC_TYPE(uint32_t, count));
 
 */


### PR DESCRIPTION
## Description of changes

For Picos the device buffer is initialized with `std::size_t` which is 32bit, but only 8bit are used per memory location.
This PR changes the device buffer to `uint8_t` also for the Pico. But as also classes or 16bit arrays get allocated in the device buffer, the return parameter is now `void*` and the calling function has to cast the return value to the correct size.
This means that every `device.cpp` and `MFdevice.cpp` has to be changed.
The check if the required memory can be allocated in the device buffer is simplified.
Further more it`s now checked if a stepper class can allocate the required memory and returns the result.

For the AVR's there is no change in allocating memory in the device buffer even the same changes in `device.cpp` apply. It's only differentiated in `allocateMem.cpp/h` to keep the code readable.

This PR is tested with each device on a Mega and Pico.

Fixes #374 
