### PR TITLE
Disable DTR on connect

### DIFF
--- a/_Boards/arduino_mega.board.json
+++ b/_Boards/arduino_mega.board.json
@@ -11,7 +11,7 @@
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": false,
     "DelayAfterFirmwareUpdate": 0,
-    "DtrEnable": true,
+    "DtrEnable": false,
     "MessageSize": 90,
     "EEPROMSize": 1496
   },

--- a/_Boards/arduino_nano.board.json
+++ b/_Boards/arduino_nano.board.json
@@ -10,7 +10,7 @@
   "Connection": {
     "ConnectionDelay": 1750,
     "DelayAfterFirmwareUpdate": 0,
-    "DtrEnable": true,
+    "DtrEnable": false,
     "EEPROMSize": 286,
     "ExtraConnectionRetry": true,
     "ForceResetOnFirmwareUpdate": false,

--- a/_Boards/arduino_uno.board.json
+++ b/_Boards/arduino_uno.board.json
@@ -10,7 +10,7 @@
   "Connection": {
     "ConnectionDelay": 1750,
     "DelayAfterFirmwareUpdate": 0,
-    "DtrEnable": true,
+    "DtrEnable": false,
     "EEPROMSize": 286,
     "ExtraConnectionRetry": true,
     "ForceResetOnFirmwareUpdate": false,

--- a/_Boards/raspberrypi_pico.board.json
+++ b/_Boards/raspberrypi_pico.board.json
@@ -7,7 +7,7 @@
   "Connection": {
     "ConnectionDelay": 1250,
     "DelayAfterFirmwareUpdate": 1250,
-    "DtrEnable": true,
+    "DtrEnable": false,
     "EEPROMSize": 1496,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": true,

--- a/_Boards/raspberrypi_pico.board.json
+++ b/_Boards/raspberrypi_pico.board.json
@@ -7,7 +7,7 @@
   "Connection": {
     "ConnectionDelay": 1250,
     "DelayAfterFirmwareUpdate": 1250,
-    "DtrEnable": false,
+    "DtrEnable": true,
     "EEPROMSize": 1496,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": true,


### PR DESCRIPTION
## Description of changes

When connecting to AVR boards with DTR enabled, these boards get resettet on connect. After resetting the boards respond at least with `17,OK;` (not processed from the connector). Other board types which are used for community devices might also respond with additional messages which could lead to an unrecognized board or set them into bootlaoder mode (could happen for some ESP32 boards).

This PR disables setting DTR line on connect for all boards except for ProMicro and Pico which requires setting the DTR line.

See also PR #2870 and issue #2849 in the connector repo.