### PR TITLE
Fixes the index offset of 1 for inputshifters

### DIFF
--- a/src/MF_Modules/MFShiftData.cpp
+++ b/src/MF_Modules/MFShiftData.cpp
@@ -6,11 +6,11 @@ uint8_t shiftInData(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
     uint8_t i;
 
     for (i = 0; i < 8; ++i) {
+        digitalWrite(clockPin, HIGH);
         if (bitOrder == LSBFIRST)
             value |= digitalRead(dataPin) << i;
         else
             value |= digitalRead(dataPin) << (7 - i);
-        digitalWrite(clockPin, HIGH);
         digitalWrite(clockPin, LOW);
 #if !defined(ARDUINO_ARCH_AVR) && !defined(ARDUINO_ARCH_RP2040)
         delayMicroseconds(1);


### PR DESCRIPTION
## Description of changes

With version 3.0/3.1 for shifting in data the Arduino Framework build in function isn't used anymore. Instead an own function is used which has additionally a delay after each bit shifted out for non AVR and non Pico processors. So for the supported processors there should be no difference, but e.g. an ESP32 (which one is faster) needs this.

This was reported on [Discord](https://discord.com/channels/608690978081210392/635953880122785824/1520811480105222185)

Making a pulse after each shifted in bit is wrong, it must be done like the original Arduino function which sets CLK to H before a bit is shifted out.

Fixes #380 
